### PR TITLE
feat(python): add missing endpoint we use in our docs

### DIFF
--- a/workflow/python/main.py
+++ b/workflow/python/main.py
@@ -75,6 +75,17 @@ def resume_workflow(workflow_id: str):
     except Exception as e:
         logger.error(f"Failed to resume workflow: {e}")
         raise HTTPException(status_code=500, detail=str(e))
+    
+@app.get("/workflow/output/{workflow_id}")
+def get_workflow_status(workflow_id: str):
+    try:
+        state = workflow_client.get_workflow_state(instance_id=workflow_id)
+        if not state:
+            return {"error": "Workflow not found", "workflow_id": workflow_id}
+        return {"workflow_id": workflow_id, "status": state.runtime_status}
+    except Exception as e:
+        logger.error(f"Failed to get workflow status: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
 
 if __name__ == "__main__":
     uvicorn.run(app, host="0.0.0.0", port=5001)


### PR DESCRIPTION
add the workflow output endpoint for python as it was missing
![image](https://github.com/user-attachments/assets/0ceb18ff-8d81-4170-b2ad-15553660b22a)


I saw in CSharp that it is the same as the workflow status endpoint, so I made it the same for python as well. @kendallroden what is the distinction between the two? Or, are they supposed to be the same?