### PR TITLE
feat(healthcheck): add healthcheck endpoint where missing

### DIFF
--- a/invocation/csharp/client/Program.cs
+++ b/invocation/csharp/client/Program.cs
@@ -12,6 +12,13 @@ var client = new DaprClientBuilder().Build();
 var DaprApiToken = Environment.GetEnvironmentVariable("DAPR_API_TOKEN") ?? "";
 var InvokeAppId = Environment.GetEnvironmentVariable("INVOKE_APPID") ?? "server";
 
+// Health check endpoint
+app.MapGet("/", () => 
+{
+    var healthMessage = "Health check passed. Everything is running smoothly! 🚀";
+    app.Logger.LogInformation("Health check result: {Message}", healthMessage);
+    return Results.Ok(healthMessage);
+});
 
 app.MapPost("/order", async (Order order) =>
 {

--- a/invocation/csharp/server/Program.cs
+++ b/invocation/csharp/server/Program.cs
@@ -16,6 +16,14 @@ app.MapPost("/neworder", (Order order) =>
     return Results.Ok(order);
 });
 
+// Health check endpoint
+app.MapGet("/", () => 
+{
+    var healthMessage = "Health check passed. Everything is running smoothly! 🚀";
+    app.Logger.LogInformation("Health check result: {Message}", healthMessage);
+    return Results.Ok(healthMessage);
+});
+
 app.Run();
 
 public record Order([property: JsonPropertyName("orderId")] int OrderId);

--- a/invocation/java/client/src/main/java/com/service/controller/Controller.java
+++ b/invocation/java/client/src/main/java/com/service/controller/Controller.java
@@ -44,6 +44,14 @@ public class Controller {
         .build();
   }
 
+  // Health check endpoint
+  @GetMapping(path = "/")
+  public ResponseEntity<String> healthCheck() {
+    String healthMessage = "Health check passed. Everything is running smoothly! 🚀";
+    logger.info("Health check result: {}", healthMessage);
+    return ResponseEntity.ok(healthMessage);
+  }
+
   // Invoke another service
   @PostMapping(path = "/order", consumes = MediaType.ALL_VALUE)
   public Mono<ResponseEntity> order(@RequestBody(required = true) Order order) {

--- a/invocation/java/server/src/main/java/com/service/controller/Controller.java
+++ b/invocation/java/server/src/main/java/com/service/controller/Controller.java
@@ -18,6 +18,14 @@ public class Controller {
     logger.info("Invocation received with data " + order.getOrderId());
     return ResponseEntity.ok(order);
   }
+
+    // Health check endpoint
+  @GetMapping(path = "/")
+  public ResponseEntity<String> healthCheck() {
+    String healthMessage = "Health check passed. Everything is running smoothly! 🚀";
+    logger.info("Health check result: {}", healthMessage);
+    return ResponseEntity.ok(healthMessage);
+  }
 }
 
 @Getter

--- a/invocation/javascript/client/index.js
+++ b/invocation/javascript/client/index.js
@@ -11,6 +11,13 @@ const app = express()
 
 app.use(bodyParser.json({ type: '*/*' }))
 
+// Health check endpoint
+app.get('/', (req, res) => {
+  const healthMessage = "Health check passed. Everything is running smoothly! 🚀";
+  console.log("Health check result: %s", healthMessage);
+  res.status(200).send(healthMessage);
+});
+
 app.post('/order', async function(req, res) {
   let config = {
     headers: {

--- a/invocation/javascript/server/index.js
+++ b/invocation/javascript/server/index.js
@@ -7,6 +7,12 @@ const app = express()
 
 app.use(bodyParser.json({ type: '*/*' }))
 
+// Health check endpoint
+app.get('/', (req, res) => {
+  const healthMessage = "Health check passed. Everything is running smoothly! 🚀";
+  console.log("Health check result: %s", healthMessage);
+  res.status(200).send(healthMessage);
+});
 
 app.post('/neworder', (req, res) => {
   console.log("Invocation received with data: %s", JSON.stringify(req.body))

--- a/pubsub/csharp/publisher/Program.cs
+++ b/pubsub/csharp/publisher/Program.cs
@@ -11,6 +11,14 @@ var PubSubName = Environment.GetEnvironmentVariable("PUBSUB_NAME") ?? "pubsub";
 
 #region Publish API 
 
+// Health check endpoint
+app.MapGet("/", () => 
+{
+    var healthMessage = "Health check passed. Everything is running smoothly! 🚀";
+    app.Logger.LogInformation("Health check result: {Message}", healthMessage);
+    return Results.Ok(healthMessage);
+});
+
 // Publish messages 
 app.MapPost("/order", async (Order order) =>
 {

--- a/pubsub/csharp/subscriber/Program.cs
+++ b/pubsub/csharp/subscriber/Program.cs
@@ -19,6 +19,14 @@ app.MapPost("/neworder", (Order order) =>
     return Results.Ok(order);
 });
 
+// Health check endpoint
+app.MapGet("/", () => 
+{
+    var healthMessage = "Health check passed. Everything is running smoothly! 🚀";
+    app.Logger.LogInformation("Health check result: {Message}", healthMessage);
+    return Results.Ok(healthMessage);
+});
+
 #endregion
 
 app.Run();

--- a/pubsub/java/publisher/src/main/java/com/service/controller/Controller.java
+++ b/pubsub/java/publisher/src/main/java/com/service/controller/Controller.java
@@ -29,6 +29,14 @@ public class Controller {
         client = new DaprClientBuilder().build();
     }
 
+    // Health check endpoint
+    @GetMapping(path = "/")
+    public ResponseEntity<String> healthCheck() {
+        String healthMessage = "Health check passed. Everything is running smoothly! 🚀";
+        logger.info("Health check result: {}", healthMessage);
+        return ResponseEntity.ok(healthMessage);
+    }
+
     // Publish messages 
     @PostMapping(path = "/order", consumes = MediaType.ALL_VALUE)
     public Mono<ResponseEntity> publish(@RequestBody(required = true) Order order) {

--- a/pubsub/java/subscriber/src/main/java/com/service/controller/Controller.java
+++ b/pubsub/java/subscriber/src/main/java/com/service/controller/Controller.java
@@ -19,6 +19,14 @@ public class Controller {
     
     private static final Logger logger = LoggerFactory.getLogger(Controller.class);
 
+    // Health check endpoint
+    @GetMapping(path = "/")
+    public ResponseEntity<String> healthCheck() {
+        String healthMessage = "Health check passed. Everything is running smoothly! 🚀";
+        logger.info("Health check result: {}", healthMessage);
+        return ResponseEntity.ok(healthMessage);
+    }
+
     @PostMapping(path = "/neworder", consumes = MediaType.ALL_VALUE)
     public Mono<ResponseEntity> subscribe(@RequestBody(required = false) CloudEvent<Order> cloudEvent) {
         return Mono.fromSupplier(() -> {

--- a/pubsub/javascript/publisher/index.js
+++ b/pubsub/javascript/publisher/index.js
@@ -13,6 +13,13 @@ app.use(bodyParser.json({ type: '*/*' }))
 
 //#region Pub/Sub API
 
+// Health check endpoint
+app.get('/', (req, res) => {
+  const healthMessage = "Health check passed. Everything is running smoothly! 🚀";
+  console.log("Health check result: %s", healthMessage);
+  res.status(200).send(healthMessage);
+});
+
 app.post('/order', async function (req, res) {
     let order = req.body
     try {

--- a/pubsub/javascript/subscriber/index.js
+++ b/pubsub/javascript/subscriber/index.js
@@ -7,6 +7,13 @@ const app = express()
 
 app.use(bodyParser.json({ type: '*/*' })) 
 
+// Health check endpoint
+app.get('/', (req, res) => {
+  const healthMessage = "Health check passed. Everything is running smoothly! 🚀";
+  console.log("Health check result: %s", healthMessage);
+  res.status(200).send(healthMessage);
+});
+
 app.post('/neworder', (req, res) => {
   console.log("Order received: " + JSON.stringify(req.body.data))
   res.sendStatus(200);

--- a/state/csharp/Program.cs
+++ b/state/csharp/Program.cs
@@ -12,6 +12,14 @@ var client = new DaprClientBuilder().Build();
 
 var stateStoreName = Environment.GetEnvironmentVariable("STATESTORE_NAME") ?? "kvstore";
 
+// Health check endpoint
+app.MapGet("/", () => 
+{
+    var healthMessage = "Health check passed. Everything is running smoothly! 🚀";
+    app.Logger.LogInformation("Health check result: {Message}", healthMessage);
+    return Results.Ok(healthMessage);
+});
+
 // Save state 
 app.MapPost("/order", async (Order order) =>
 {

--- a/state/java/src/main/java/com/service/controller/Controller.java
+++ b/state/java/src/main/java/com/service/controller/Controller.java
@@ -33,6 +33,14 @@ public class Controller {
         client = new DaprClientBuilder().build();
     }
 
+    // Health check endpoint
+    @GetMapping(path = "/")
+    public ResponseEntity<String> healthCheck() {
+        String healthMessage = "Health check passed. Everything is running smoothly! 🚀";
+        logger.info("Health check result: {}", healthMessage);
+        return ResponseEntity.ok(healthMessage);
+    }
+
     // Save state
     @PostMapping(path = "/order", consumes = MediaType.ALL_VALUE)
     public Mono<ResponseEntity> saveState(@RequestBody(required = true) Order order) {

--- a/state/javascript/index.js
+++ b/state/javascript/index.js
@@ -11,6 +11,13 @@ const client = new DaprClient();
 
 app.use(bodyParser.json({ type: '*/*' })) 
 
+// Health check endpoint
+app.get('/', (req, res) => {
+  const healthMessage = "Health check passed. Everything is running smoothly! 🚀";
+  console.log("Health check result: %s", healthMessage);
+  res.status(200).send(healthMessage);
+});
+
 app.post('/order', async function (req, res) {
   req.accepts('application/json')
 

--- a/workflow/csharp/Program.cs
+++ b/workflow/csharp/Program.cs
@@ -23,6 +23,14 @@ app.UseCloudEvents();
 
 #region Workflow API
 
+// Health check endpoint
+app.MapGet("/", () => 
+{
+    var healthMessage = "Health check passed. Everything is running smoothly! 🚀";
+    app.Logger.LogInformation("Health check result: {Message}", healthMessage);
+    return Results.Ok(healthMessage);
+});
+
 // Start new workflow
 app.MapPost("/workflow/start", async (OrderPayload order) =>
 {


### PR DESCRIPTION
I see python is the only one with a health check endpoint
```
@app.get('/')

```

This PR adds that to the rest of the languages. It is confusing for UX when someone uses the dev start CLI command and sees a bunch of 404s bc we are missing this endpoint across the board.


example output from before
```

== APP - 2024-10-01 10:45:59.490572 -0500 CDT m=+58.608159376 - order-workflow == info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
== APP - 2024-10-01 10:45:59.490774 -0500 CDT m=+58.608361376 - order-workflow ==       Request finished HTTP/1.1 GET http://461377-cli-461373-67ee5120-b475-423b-9f23-b4eca82b1e6e.tunnel.dev.diagrid.io/ - 404 0 - 0.2781ms
== APP - 2024-10-01 10:45:59.490783 -0500 CDT m=+58.608371085 - order-workflow == info: Microsoft.AspNetCore.Hosting.Diagnostics[16]
== APP - 2024-10-01 10:45:59.490893 -0500 CDT m=+58.608481043 - order-workflow ==       Request reached the end of the middleware pipeline without being handled by application code. Request path: GET http://461377-cli-461373-67ee5120-b475-423b-9f23-b4eca82b1e6e.tunnel.dev.diagrid.io/, Response status code: 404
== APP - 2024-10-01 10:46:07.468714 -0500 CDT m=+66.586286293 - order-workflow == info: Microsoft.AspNetCore.Hosting.Diagnostics[1]
== APP - 2024-10-01 10:46:07.468844 -0500 CDT m=+66.586416335 - order-workflow ==       Request starting HTTP/1.1 GET http://461377-cli-461373-67ee5120-b475-423b-9f23-b4eca82b1e6e.tunnel.dev.diagrid.io/ - - -
```

with changes
```

== APP - 2024-10-01 10:52:07.805756 -0500 CDT m=+29.962226043 - order-workflow == info: Microsoft.AspNetCore.Routing.EndpointMiddleware[0]
== APP - 2024-10-01 10:52:07.805774 -0500 CDT m=+29.962244835 - order-workflow ==       Executing endpoint 'HTTP: GET /'
== APP - 2024-10-01 10:52:07.805781 -0500 CDT m=+29.962251793 - order-workflow == info: WorkflowApp[0]
== APP - 2024-10-01 10:52:07.80579 -0500 CDT m=+29.962260626 - order-workflow ==       Health check result: Health check passed. Everything is running smoothly! 🚀
== APP - 2024-10-01 10:52:07.805798 -0500 CDT m=+29.962268210 - order-workflow == info: Microsoft.AspNetCore.Http.Result.OkObjectResult[1]
== APP - 2024-10-01 10:52:07.806204 -0500 CDT m=+29.962673960 - order-workflow ==       Setting HTTP status code 200.
```