### PR TITLE
fix(release): capture if status is empty to avoid py err

### DIFF
--- a/invocation/csharp/run.py
+++ b/invocation/csharp/run.py
@@ -72,7 +72,6 @@ def create_appid(project_name, appid_name):
                 spinner.write(f"Error: {e.stderr}")
             sys.exit(1)
 
-
 def check_appid_status(project_name, appid_name):
     max_attempts = 8
     attempt = 1
@@ -82,17 +81,20 @@ def check_appid_status(project_name, appid_name):
         while attempt <= max_attempts:
             status_output = run_command(f"diagrid appid get {appid_name} -p {project_name}")
 
-            status_lines = status_output.split('\n')
-            status = None
-            for line in status_lines:
-                if 'Status:' in line:
-                    status = line.split('Status:')[1].strip()
-                    last_status = status
-                    break
+            if status_output is None:
+                spinner.write(f"App ID {appid_name} is still provisioning. Retrying...") 
+            else:          
+                status_lines = status_output.split('\n')
+                status = None
+                for line in status_lines:
+                    if 'Status:' in line:
+                        status = line.split('Status:')[1].strip()
+                        last_status = status
+                        break
 
-            if status and (status.lower() == "ready" or status.lower() == "available"):
-                spinner.ok("✅")
-                return 
+                if status and (status.lower() == "ready" or status.lower() == "available"):
+                    spinner.ok("✅")
+                    return 
 
             time.sleep(10)
             attempt += 1

--- a/invocation/java/run.py
+++ b/invocation/java/run.py
@@ -103,7 +103,6 @@ def create_appid(project_name, appid_name):
                 spinner.write(f"Error: {e.stderr}")
             sys.exit(1)
 
-
 def check_appid_status(project_name, appid_name):
     max_attempts = 8
     attempt = 1
@@ -113,17 +112,20 @@ def check_appid_status(project_name, appid_name):
         while attempt <= max_attempts:
             status_output = run_command(f"diagrid appid get {appid_name} -p {project_name}")
 
-            status_lines = status_output.split('\n')
-            status = None
-            for line in status_lines:
-                if 'Status:' in line:
-                    status = line.split('Status:')[1].strip()
-                    last_status = status
-                    break
+            if status_output is None:
+                spinner.write(f"App ID {appid_name} is still provisioning. Retrying...") 
+            else:          
+                status_lines = status_output.split('\n')
+                status = None
+                for line in status_lines:
+                    if 'Status:' in line:
+                        status = line.split('Status:')[1].strip()
+                        last_status = status
+                        break
 
-            if status and (status.lower() == "ready" or status.lower() == "available"):
-                spinner.ok("✅")
-                return 
+                if status and (status.lower() == "ready" or status.lower() == "available"):
+                    spinner.ok("✅")
+                    return 
 
             time.sleep(10)
             attempt += 1

--- a/invocation/javascript/run.py
+++ b/invocation/javascript/run.py
@@ -66,7 +66,6 @@ def create_appid(project_name, appid_name):
                 spinner.write(f"Error: {e.stderr}")
             sys.exit(1)
 
-
 def check_appid_status(project_name, appid_name):
     max_attempts = 8
     attempt = 1
@@ -76,17 +75,20 @@ def check_appid_status(project_name, appid_name):
         while attempt <= max_attempts:
             status_output = run_command(f"diagrid appid get {appid_name} -p {project_name}")
 
-            status_lines = status_output.split('\n')
-            status = None
-            for line in status_lines:
-                if 'Status:' in line:
-                    status = line.split('Status:')[1].strip()
-                    last_status = status
-                    break
+            if status_output is None:
+                spinner.write(f"App ID {appid_name} is still provisioning. Retrying...") 
+            else:          
+                status_lines = status_output.split('\n')
+                status = None
+                for line in status_lines:
+                    if 'Status:' in line:
+                        status = line.split('Status:')[1].strip()
+                        last_status = status
+                        break
 
-            if status and (status.lower() == "ready" or status.lower() == "available"):
-                spinner.ok("✅")
-                return 
+                if status and (status.lower() == "ready" or status.lower() == "available"):
+                    spinner.ok("✅")
+                    return 
 
             time.sleep(10)
             attempt += 1

--- a/invocation/python/run.py
+++ b/invocation/python/run.py
@@ -72,7 +72,6 @@ def create_appid(project_name, appid_name):
                 spinner.write(f"Error: {e.stderr}")
             sys.exit(1)
 
-
 def check_appid_status(project_name, appid_name):
     max_attempts = 8
     attempt = 1
@@ -82,17 +81,20 @@ def check_appid_status(project_name, appid_name):
         while attempt <= max_attempts:
             status_output = run_command(f"diagrid appid get {appid_name} -p {project_name}")
 
-            status_lines = status_output.split('\n')
-            status = None
-            for line in status_lines:
-                if 'Status:' in line:
-                    status = line.split('Status:')[1].strip()
-                    last_status = status
-                    break
+            if status_output is None:
+                spinner.write(f"App ID {appid_name} is still provisioning. Retrying...") 
+            else:          
+                status_lines = status_output.split('\n')
+                status = None
+                for line in status_lines:
+                    if 'Status:' in line:
+                        status = line.split('Status:')[1].strip()
+                        last_status = status
+                        break
 
-            if status and (status.lower() == "ready" or status.lower() == "available"):
-                spinner.ok("✅")
-                return 
+                if status and (status.lower() == "ready" or status.lower() == "available"):
+                    spinner.ok("✅")
+                    return 
 
             time.sleep(10)
             attempt += 1

--- a/pubsub/csharp/run.py
+++ b/pubsub/csharp/run.py
@@ -86,7 +86,6 @@ def create_subscription(project_name, subscription_name, topic_name, route):
                 spinner.write(f"{e.stderr}")
             sys.exit(1)
 
-
 def check_appid_status(project_name, appid_name):
     max_attempts = 8
     attempt = 1
@@ -96,17 +95,20 @@ def check_appid_status(project_name, appid_name):
         while attempt <= max_attempts:
             status_output = run_command(f"diagrid appid get {appid_name} -p {project_name}")
 
-            status_lines = status_output.split('\n')
-            status = None
-            for line in status_lines:
-                if 'Status:' in line:
-                    status = line.split('Status:')[1].strip()
-                    last_status = status
-                    break
+            if status_output is None:
+                spinner.write(f"App ID {appid_name} is still provisioning. Retrying...") 
+            else:          
+                status_lines = status_output.split('\n')
+                status = None
+                for line in status_lines:
+                    if 'Status:' in line:
+                        status = line.split('Status:')[1].strip()
+                        last_status = status
+                        break
 
-            if status and (status.lower() == "ready" or status.lower() == "available"):
-                spinner.ok("✅")
-                return 
+                if status and (status.lower() == "ready" or status.lower() == "available"):
+                    spinner.ok("✅")
+                    return 
 
             time.sleep(10)
             attempt += 1

--- a/pubsub/java/run.py
+++ b/pubsub/java/run.py
@@ -116,7 +116,6 @@ def create_subscription(project_name, subscription_name, topic_name, route):
                 spinner.write(f"{e.stderr}")
             sys.exit(1)
 
-
 def check_appid_status(project_name, appid_name):
     max_attempts = 8
     attempt = 1
@@ -126,17 +125,20 @@ def check_appid_status(project_name, appid_name):
         while attempt <= max_attempts:
             status_output = run_command(f"diagrid appid get {appid_name} -p {project_name}")
 
-            status_lines = status_output.split('\n')
-            status = None
-            for line in status_lines:
-                if 'Status:' in line:
-                    status = line.split('Status:')[1].strip()
-                    last_status = status
-                    break
+            if status_output is None:
+                spinner.write(f"App ID {appid_name} is still provisioning. Retrying...") 
+            else:          
+                status_lines = status_output.split('\n')
+                status = None
+                for line in status_lines:
+                    if 'Status:' in line:
+                        status = line.split('Status:')[1].strip()
+                        last_status = status
+                        break
 
-            if status and (status.lower() == "ready" or status.lower() == "available"):
-                spinner.ok("✅")
-                return 
+                if status and (status.lower() == "ready" or status.lower() == "available"):
+                    spinner.ok("✅")
+                    return 
 
             time.sleep(10)
             attempt += 1

--- a/pubsub/javascript/run.py
+++ b/pubsub/javascript/run.py
@@ -79,7 +79,6 @@ def create_subscription(project_name, subscription_name, topic_name, route):
                 spinner.write(f"{e.stderr}")
             sys.exit(1)
 
-
 def check_appid_status(project_name, appid_name):
     max_attempts = 8
     attempt = 1
@@ -89,17 +88,20 @@ def check_appid_status(project_name, appid_name):
         while attempt <= max_attempts:
             status_output = run_command(f"diagrid appid get {appid_name} -p {project_name}")
 
-            status_lines = status_output.split('\n')
-            status = None
-            for line in status_lines:
-                if 'Status:' in line:
-                    status = line.split('Status:')[1].strip()
-                    last_status = status
-                    break
+            if status_output is None:
+                spinner.write(f"App ID {appid_name} is still provisioning. Retrying...") 
+            else:          
+                status_lines = status_output.split('\n')
+                status = None
+                for line in status_lines:
+                    if 'Status:' in line:
+                        status = line.split('Status:')[1].strip()
+                        last_status = status
+                        break
 
-            if status and (status.lower() == "ready" or status.lower() == "available"):
-                spinner.ok("✅")
-                return 
+                if status and (status.lower() == "ready" or status.lower() == "available"):
+                    spinner.ok("✅")
+                    return 
 
             time.sleep(10)
             attempt += 1

--- a/pubsub/python/run.py
+++ b/pubsub/python/run.py
@@ -85,7 +85,6 @@ def create_subscription(project_name, subscription_name, topic_name, route):
                 spinner.write(f"{e.stderr}")
             sys.exit(1)
 
-
 def check_appid_status(project_name, appid_name):
     max_attempts = 8
     attempt = 1
@@ -95,17 +94,20 @@ def check_appid_status(project_name, appid_name):
         while attempt <= max_attempts:
             status_output = run_command(f"diagrid appid get {appid_name} -p {project_name}")
 
-            status_lines = status_output.split('\n')
-            status = None
-            for line in status_lines:
-                if 'Status:' in line:
-                    status = line.split('Status:')[1].strip()
-                    last_status = status
-                    break
+            if status_output is None:
+                spinner.write(f"App ID {appid_name} is still provisioning. Retrying...") 
+            else:          
+                status_lines = status_output.split('\n')
+                status = None
+                for line in status_lines:
+                    if 'Status:' in line:
+                        status = line.split('Status:')[1].strip()
+                        last_status = status
+                        break
 
-            if status and (status.lower() == "ready" or status.lower() == "available"):
-                spinner.ok("✅")
-                return 
+                if status and (status.lower() == "ready" or status.lower() == "available"):
+                    spinner.ok("✅")
+                    return 
 
             time.sleep(10)
             attempt += 1

--- a/state/csharp/run.py
+++ b/state/csharp/run.py
@@ -78,17 +78,20 @@ def check_appid_status(project_name, appid_name):
         while attempt <= max_attempts:
             status_output = run_command(f"diagrid appid get {appid_name} -p {project_name}")
 
-            status_lines = status_output.split('\n')
-            status = None
-            for line in status_lines:
-                if 'Status:' in line:
-                    status = line.split('Status:')[1].strip()
-                    last_status = status
-                    break
+            if status_output is None:
+                spinner.write(f"App ID {appid_name} is still provisioning. Retrying...") 
+            else:          
+                status_lines = status_output.split('\n')
+                status = None
+                for line in status_lines:
+                    if 'Status:' in line:
+                        status = line.split('Status:')[1].strip()
+                        last_status = status
+                        break
 
-            if status and (status.lower() == "ready" or status.lower() == "available"):
-                spinner.ok("✅")
-                return 
+                if status and (status.lower() == "ready" or status.lower() == "available"):
+                    spinner.ok("✅")
+                    return 
 
             time.sleep(10)
             attempt += 1

--- a/state/java/run.py
+++ b/state/java/run.py
@@ -109,17 +109,20 @@ def check_appid_status(project_name, appid_name):
         while attempt <= max_attempts:
             status_output = run_command(f"diagrid appid get {appid_name} -p {project_name}")
 
-            status_lines = status_output.split('\n')
-            status = None
-            for line in status_lines:
-                if 'Status:' in line:
-                    status = line.split('Status:')[1].strip()
-                    last_status = status
-                    break
+            if status_output is None:
+                spinner.write(f"App ID {appid_name} is still provisioning. Retrying...") 
+            else:          
+                status_lines = status_output.split('\n')
+                status = None
+                for line in status_lines:
+                    if 'Status:' in line:
+                        status = line.split('Status:')[1].strip()
+                        last_status = status
+                        break
 
-            if status and (status.lower() == "ready" or status.lower() == "available"):
-                spinner.ok("✅")
-                return 
+                if status and (status.lower() == "ready" or status.lower() == "available"):
+                    spinner.ok("✅")
+                    return 
 
             time.sleep(10)
             attempt += 1
@@ -128,7 +131,7 @@ def check_appid_status(project_name, appid_name):
         spinner.write(f"App ID {appid_name} is still provisioning")
         spinner.write(f"Run `diagrid appid get {appid_name} --project {project_name}` and proceed with quickstart once in ready status")
         sys.exit(1)
-
+        
 def set_default_project(project_name):
     with yaspin(text=f"Setting default project to {project_name}...") as spinner:
         try:

--- a/state/javascript/run.py
+++ b/state/javascript/run.py
@@ -74,17 +74,20 @@ def check_appid_status(project_name, appid_name):
         while attempt <= max_attempts:
             status_output = run_command(f"diagrid appid get {appid_name} -p {project_name}")
 
-            status_lines = status_output.split('\n')
-            status = None
-            for line in status_lines:
-                if 'Status:' in line:
-                    status = line.split('Status:')[1].strip()
-                    last_status = status
-                    break
+            if status_output is None:
+                spinner.write(f"App ID {appid_name} is still provisioning. Retrying...") 
+            else:          
+                status_lines = status_output.split('\n')
+                status = None
+                for line in status_lines:
+                    if 'Status:' in line:
+                        status = line.split('Status:')[1].strip()
+                        last_status = status
+                        break
 
-            if status and (status.lower() == "ready" or status.lower() == "available"):
-                spinner.ok("✅")
-                return 
+                if status and (status.lower() == "ready" or status.lower() == "available"):
+                    spinner.ok("✅")
+                    return 
 
             time.sleep(10)
             attempt += 1

--- a/state/python/run.py
+++ b/state/python/run.py
@@ -79,17 +79,20 @@ def check_appid_status(project_name, appid_name):
         while attempt <= max_attempts:
             status_output = run_command(f"diagrid appid get {appid_name} -p {project_name}")
 
-            status_lines = status_output.split('\n')
-            status = None
-            for line in status_lines:
-                if 'Status:' in line:
-                    status = line.split('Status:')[1].strip()
-                    last_status = status
-                    break
+            if status_output is None:
+                spinner.write(f"App ID {appid_name} is still provisioning. Retrying...") 
+            else:          
+                status_lines = status_output.split('\n')
+                status = None
+                for line in status_lines:
+                    if 'Status:' in line:
+                        status = line.split('Status:')[1].strip()
+                        last_status = status
+                        break
 
-            if status and (status.lower() == "ready" or status.lower() == "available"):
-                spinner.ok("✅")
-                return 
+                if status and (status.lower() == "ready" or status.lower() == "available"):
+                    spinner.ok("✅")
+                    return 
 
             time.sleep(10)
             attempt += 1
@@ -98,6 +101,7 @@ def check_appid_status(project_name, appid_name):
         spinner.write(f"App ID {appid_name} is still provisioning")
         spinner.write(f"Run `diagrid appid get {appid_name} --project {project_name}` and proceed with quickstart once in ready status")
         sys.exit(1)
+
 
 def set_default_project(project_name):
     with yaspin(text=f"Setting default project to {project_name}...") as spinner:

--- a/workflow/csharp/run.py
+++ b/workflow/csharp/run.py
@@ -78,17 +78,20 @@ def check_appid_status(project_name, appid_name):
         while attempt <= max_attempts:
             status_output = run_command(f"diagrid appid get {appid_name} -p {project_name}")
 
-            status_lines = status_output.split('\n')
-            status = None
-            for line in status_lines:
-                if 'Status:' in line:
-                    status = line.split('Status:')[1].strip()
-                    last_status = status
-                    break
+            if status_output is None:
+                spinner.write(f"App ID {appid_name} is still provisioning. Retrying...") 
+            else:          
+                status_lines = status_output.split('\n')
+                status = None
+                for line in status_lines:
+                    if 'Status:' in line:
+                        status = line.split('Status:')[1].strip()
+                        last_status = status
+                        break
 
-            if status and (status.lower() == "ready" or status.lower() == "available"):
-                spinner.ok("✅")
-                return 
+                if status and (status.lower() == "ready" or status.lower() == "available"):
+                    spinner.ok("✅")
+                    return 
 
             time.sleep(10)
             attempt += 1
@@ -97,6 +100,7 @@ def check_appid_status(project_name, appid_name):
         spinner.write(f"App ID {appid_name} is still provisioning")
         spinner.write(f"Run `diagrid appid get {appid_name} --project {project_name}` and proceed with quickstart once in ready status")
         sys.exit(1)
+
 
 def set_default_project(project_name):
     with yaspin(text=f"Setting default project to {project_name}...") as spinner:

--- a/workflow/java/run.py
+++ b/workflow/java/run.py
@@ -108,17 +108,20 @@ def check_appid_status(project_name, appid_name):
         while attempt <= max_attempts:
             status_output = run_command(f"diagrid appid get {appid_name} -p {project_name}")
 
-            status_lines = status_output.split('\n')
-            status = None
-            for line in status_lines:
-                if 'Status:' in line:
-                    status = line.split('Status:')[1].strip()
-                    last_status = status
-                    break
+            if status_output is None:
+                spinner.write(f"App ID {appid_name} is still provisioning. Retrying...") 
+            else:          
+                status_lines = status_output.split('\n')
+                status = None
+                for line in status_lines:
+                    if 'Status:' in line:
+                        status = line.split('Status:')[1].strip()
+                        last_status = status
+                        break
 
-            if status and (status.lower() == "ready" or status.lower() == "available"):
-                spinner.ok("✅")
-                return 
+                if status and (status.lower() == "ready" or status.lower() == "available"):
+                    spinner.ok("✅")
+                    return 
 
             time.sleep(10)
             attempt += 1

--- a/workflow/javascript/run.py
+++ b/workflow/javascript/run.py
@@ -74,17 +74,20 @@ def check_appid_status(project_name, appid_name):
         while attempt <= max_attempts:
             status_output = run_command(f"diagrid appid get {appid_name} -p {project_name}")
 
-            status_lines = status_output.split('\n')
-            status = None
-            for line in status_lines:
-                if 'Status:' in line:
-                    status = line.split('Status:')[1].strip()
-                    last_status = status
-                    break
+            if status_output is None:
+                spinner.write(f"App ID {appid_name} is still provisioning. Retrying...") 
+            else:          
+                status_lines = status_output.split('\n')
+                status = None
+                for line in status_lines:
+                    if 'Status:' in line:
+                        status = line.split('Status:')[1].strip()
+                        last_status = status
+                        break
 
-            if status and (status.lower() == "ready" or status.lower() == "available"):
-                spinner.ok("✅")
-                return 
+                if status and (status.lower() == "ready" or status.lower() == "available"):
+                    spinner.ok("✅")
+                    return 
 
             time.sleep(10)
             attempt += 1

--- a/workflow/python/run.py
+++ b/workflow/python/run.py
@@ -79,17 +79,20 @@ def check_appid_status(project_name, appid_name):
         while attempt <= max_attempts:
             status_output = run_command(f"diagrid appid get {appid_name} -p {project_name}")
 
-            status_lines = status_output.split('\n')
-            status = None
-            for line in status_lines:
-                if 'Status:' in line:
-                    status = line.split('Status:')[1].strip()
-                    last_status = status
-                    break
+            if status_output is None:
+                spinner.write(f"App ID {appid_name} is still provisioning. Retrying...") 
+            else:          
+                status_lines = status_output.split('\n')
+                status = None
+                for line in status_lines:
+                    if 'Status:' in line:
+                        status = line.split('Status:')[1].strip()
+                        last_status = status
+                        break
 
-            if status and (status.lower() == "ready" or status.lower() == "available"):
-                spinner.ok("✅")
-                return 
+                if status and (status.lower() == "ready" or status.lower() == "available"):
+                    spinner.ok("✅")
+                    return 
 
             time.sleep(10)
             attempt += 1


### PR DESCRIPTION
fixes issue we're seeing on the cli release
```
(most recent call last):
  File "/home/runner/_work/cli/cli/tests/integration/cloudruntime/state-quickstart-javascript-project-1e8bfd/state-quickstart-javascript-project-1e8bfd/run.py", line 218, in <module>
  File "/home/runner/_work/cli/cli/tests/integration/cloudruntime/state-quickstart-javascript-project-1e8bfd/state-quickstart-javascript-project-1e8bfd/run.py", line 198, in main
  File "/home/runner/_work/cli/cli/tests/integration/cloudruntime/state-quickstart-javascript-project-1e8bfd/state-quickstart-javascript-project-1e8bfd/run.py", line 112, in check_appid_status
AttributeError: 'NoneType' object has no attribute 'split'
    tests.go:595: 
        	Error Trace:	/home/runner/_work/cli/cli/tests/suites/release_validation/tests.go:595
        	            				/home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.6.linux-amd64/src/runtime/asm_amd64.s:1695
        	Error:      	"○  Checking Python dependency required to run the quickstart setup script...\n✓  Supported version found: Python 3+ \n○  Scaffolding quickstart project with name state-quickstart-csharp-project\n○  Downloading sample application code from [https://github.com/diagridio/catalyst-quickstarts...\n✓](https://github.com/diagridio/catalyst-quickstarts.../n%E2%9C%93)  Downloaded application code to directory: state-quickstart-javascript-project-1e8bfd\n○  Creating project resources and scaffolding dev config...\n" does not contain "navigate to that directory and interact with Catalyst by following the doc"
        	Test:       	TestSuites/TestReleaseValidationRunner/TestReleaseValidation/quickstarts/kv
        	Messages:   	expected output to contain navigate to that directory and interact with Catalyst by following the doc but got ○  Checking Python dependency required to run the quickstart setup script...
        	            	✓  Supported version found: Python 3+ 
        	            	○  Scaffolding quickstart project with name state-quickstart-csharp-project
        	            	○  Downloading sample application code from https://github.com/diagridio/catalyst-quickstarts...
        	            	✓  Downloaded application code to directory: state-quickstart-javascript-project-1e8bfd
        	            	○  Creating project resources and scaffolding dev config...
```