### PR TITLE
Update Axios to version 1.8.2 across all JavaScript projects

### DIFF
--- a/invocation/javascript/client/package-lock.json
+++ b/invocation/javascript/client/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@dapr/dapr": "^3.4.1",
-        "axios": "^1.7.4",
+        "axios": "^1.8.2",
         "body-parser": "^1.20.3",
         "express": "^4.21.0",
         "send": "^0.19.0",
@@ -214,9 +214,10 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/invocation/javascript/client/package.json
+++ b/invocation/javascript/client/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "@dapr/dapr": "^3.4.1",
-    "axios": "^1.7.4",
+    "axios": "^1.8.2",
     "body-parser": "^1.20.3",
     "express": "^4.21.0",
     "send": "^0.19.0",

--- a/invocation/javascript/server/package-lock.json
+++ b/invocation/javascript/server/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@dapr/dapr": "^3.4.1",
-        "axios": "^1.7.4",
+        "axios": "^1.8.2",
         "body-parser": "^1.20.3",
         "express": "^4.21.0",
         "send": "^0.19.0",
@@ -214,9 +214,10 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/invocation/javascript/server/package.json
+++ b/invocation/javascript/server/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "@dapr/dapr": "^3.4.1",
-    "axios": "^1.7.4",
+    "axios": "^1.8.2",
     "body-parser": "^1.20.3",
     "express": "^4.21.0",
     "send": "^0.19.0",

--- a/pubsub/javascript/publisher/package-lock.json
+++ b/pubsub/javascript/publisher/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@dapr/dapr": "^3.4.1",
-        "axios": "^1.7.4",
+        "axios": "^1.8.2",
         "body-parser": "^1.20.2",
         "cloudevents": "^8.0.0",
         "express": "^4.21.0",
@@ -270,9 +270,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.5.tgz",
-      "integrity": "sha512-fZu86yCo+svH3uqJ/yTdQ0QHpQu5oL+/QE+QPSv6BZSkDAoky9vytxp7u5qk83OJFS3kEBcesWni9WTZAv3tSw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",

--- a/pubsub/javascript/publisher/package.json
+++ b/pubsub/javascript/publisher/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "@dapr/dapr": "^3.4.1",
-    "axios": "^1.7.4",
+    "axios": "^1.8.2",
     "body-parser": "^1.20.2",
     "cloudevents": "^8.0.0",
     "express": "^4.21.0",

--- a/pubsub/javascript/subscriber/package-lock.json
+++ b/pubsub/javascript/subscriber/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@dapr/dapr": "^3.4.1",
-        "axios": "^1.7.4",
+        "axios": "^1.8.2",
         "body-parser": "^1.20.2",
         "cloudevents": "^8.0.0",
         "express": "^4.21.0",
@@ -270,9 +270,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.5.tgz",
-      "integrity": "sha512-fZu86yCo+svH3uqJ/yTdQ0QHpQu5oL+/QE+QPSv6BZSkDAoky9vytxp7u5qk83OJFS3kEBcesWni9WTZAv3tSw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",

--- a/pubsub/javascript/subscriber/package.json
+++ b/pubsub/javascript/subscriber/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "@dapr/dapr": "^3.4.1",
-    "axios": "^1.7.4",
+    "axios": "^1.8.2",
     "body-parser": "^1.20.2",
     "cloudevents": "^8.0.0",
     "express": "^4.21.0",

--- a/state/javascript/package-lock.json
+++ b/state/javascript/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@dapr/dapr": "^3.4.1",
-        "axios": "^1.7.4",
+        "axios": "^1.8.2",
         "body-parser": "^1.20.2",
         "cloudevents": "^8.0.2",
         "express": "^4.21.0",
@@ -270,9 +270,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.5.tgz",
-      "integrity": "sha512-fZu86yCo+svH3uqJ/yTdQ0QHpQu5oL+/QE+QPSv6BZSkDAoky9vytxp7u5qk83OJFS3kEBcesWni9WTZAv3tSw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",

--- a/state/javascript/package.json
+++ b/state/javascript/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "@dapr/dapr": "^3.4.1",
-    "axios": "^1.7.4",
+    "axios": "^1.8.2",
     "body-parser": "^1.20.2",
     "cloudevents": "^8.0.2",
     "express": "^4.21.0",

--- a/workflow/javascript/package-lock.json
+++ b/workflow/javascript/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@dapr/dapr": "^3.4.1",
-        "axios": "^1.7.4",
+        "axios": "^1.8.2",
         "body-parser": "^1.20.3",
         "cloudevents": "^8.0.2",
         "express": "^4.21.0"
@@ -268,9 +268,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.5.tgz",
-      "integrity": "sha512-fZu86yCo+svH3uqJ/yTdQ0QHpQu5oL+/QE+QPSv6BZSkDAoky9vytxp7u5qk83OJFS3kEBcesWni9WTZAv3tSw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",

--- a/workflow/javascript/package.json
+++ b/workflow/javascript/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "@dapr/dapr": "^3.4.1",
-    "axios": "^1.7.4",
+    "axios": "^1.8.2",
     "body-parser": "^1.20.3",
     "cloudevents": "^8.0.2",
     "express": "^4.21.0"


### PR DESCRIPTION
Upgraded the Axios dependency from versions 1.7.4 and 1.7.5 to 1.8.2 in multiple package.json and package-lock.json files. This ensures all projects use the latest compatible version, improving security and benefiting from bug fixes.