### PR TITLE
drop managed svc yaml

### DIFF
--- a/pubsub/csharp/pubsub.yaml
+++ b/pubsub/csharp/pubsub.yaml
@@ -1,6 +1,0 @@
-apiVersion: cra.diagrid.io/v1beta1
-kind: Pubsub
-metadata:
-  name: pubsub
-spec:
-  createComponent: true

--- a/pubsub/java/pubsub.yaml
+++ b/pubsub/java/pubsub.yaml
@@ -1,6 +1,0 @@
-apiVersion: cra.diagrid.io/v1beta1
-kind: Pubsub
-metadata:
-  name: pubsub
-spec:
-  createComponent: true

--- a/pubsub/javascript/pubsub.yaml
+++ b/pubsub/javascript/pubsub.yaml
@@ -1,6 +1,0 @@
-apiVersion: cra.diagrid.io/v1beta1
-kind: Pubsub
-metadata:
-  name: pubsub
-spec:
-  createComponent: true

--- a/pubsub/python/pubsub.yaml
+++ b/pubsub/python/pubsub.yaml
@@ -1,6 +1,0 @@
-apiVersion: cra.diagrid.io/v1beta1
-kind: Pubsub
-metadata:
-  name: pubsub
-spec:
-  createComponent: true

--- a/state/csharp/kvstore.yaml
+++ b/state/csharp/kvstore.yaml
@@ -1,6 +1,0 @@
-apiVersion: cra.diagrid.io/v1beta1
-kind: KVStore
-metadata:
-  name: kvstore
-spec:
-  createComponent: true

--- a/state/java/kvstore.yaml
+++ b/state/java/kvstore.yaml
@@ -1,6 +1,0 @@
-apiVersion: cra.diagrid.io/v1beta1
-kind: KVStore
-metadata:
-  name: kvstore
-spec:
-  createComponent: true

--- a/state/javascript/kvstore.yaml
+++ b/state/javascript/kvstore.yaml
@@ -1,6 +1,0 @@
-apiVersion: cra.diagrid.io/v1beta1
-kind: KVStore
-metadata:
-  name: kvstore
-spec:
-  createComponent: true

--- a/state/python/kvstore.yaml
+++ b/state/python/kvstore.yaml
@@ -1,6 +1,0 @@
-apiVersion: cra.diagrid.io/v1beta1
-kind: KVStore
-metadata:
-  name: kvstore
-spec:
-  createComponent: true


### PR DESCRIPTION
Now dev run will enable managed svc for SaaS by default, we don't need these definitions any more, otherwise it cause:
```
📁 Loading resources from pubsub.yaml
❌ Error loading resources: unsupported API: cra.diagrid.io/v1beta1/Pubsub
Unsupported API: cra.diagrid.io/v1beta1/Pubsub
```