### PR TITLE
Fix venv folder name and orchestrator URL in READMEs

### DIFF
--- a/agents/adk/README.md
+++ b/agents/adk/README.md
@@ -22,8 +22,8 @@ This quickstart demonstrates how to run a Google ADK (Agent Development Kit) age
 cd adk
 
 # Create and activate virtual environment
-python -m venv venv
-source venv/bin/activate  # On macOS/Linux
+python -m venv .venv
+source .venv/bin/activate  # On macOS/Linux
 
 # Install dependencies
 pip install -r requirements.txt

--- a/agents/crewai/README.md
+++ b/agents/crewai/README.md
@@ -22,8 +22,8 @@ This quickstart demonstrates how to run a CrewAI agent as a durable Dapr Workflo
 cd crewai
 
 # Create and activate virtual environment
-python -m venv venv
-source venv/bin/activate  # On macOS/Linux
+python -m venv .venv
+source .venv/bin/activate  # On macOS/Linux
 
 # Install dependencies
 pip install -r requirements.txt

--- a/agents/dapr-agents/durable-agent/README.md
+++ b/agents/dapr-agents/durable-agent/README.md
@@ -23,8 +23,8 @@ Inside the project directory, run the following commands:
 
 ```bash
 # Create and activate virtual environment
-python -m venv venv
-source venv/bin/activate  # On macOS/Linux
+python -m venv .venv
+source .venv/bin/activate  # On macOS/Linux
 
 # Install dependencies
 pip install -r requirements.txt

--- a/agents/dapr-agents/orchestrator/README.md
+++ b/agents/dapr-agents/orchestrator/README.md
@@ -24,8 +24,8 @@ This quickstart demonstrates how to build an **orchestrator agent** using [Dapr 
 cd dapr-agents/orchestrator
 
 # Create and activate virtual environment
-python -m venv venv
-source venv/bin/activate  # On macOS/Linux
+python -m venv .venv
+source .venv/bin/activate  # On macOS/Linux
 
 # Install dependencies
 pip install -r requirements.txt
@@ -76,7 +76,7 @@ This starts all agents on ports 8001-8008:
 Once all agents are running, send a task to the orchestrator:
 
 ```bash
-curl -i -X POST http://localhost:8004/run \
+curl -i -X POST http://localhost:8004/agent/run \
   -H "Content-Type: application/json" \
   -d '{"task": "Plan a company offsite in Austin for 50 people"}'
 ```

--- a/agents/langgraph/README.md
+++ b/agents/langgraph/README.md
@@ -23,8 +23,8 @@ This quickstart demonstrates how to run a LangGraph graph as a durable Dapr Work
 cd langgraph
 
 # Create and activate virtual environment
-python -m venv venv
-source venv/bin/activate  # On macOS/Linux
+python -m venv .venv
+source .venv/bin/activate  # On macOS/Linux
 
 # Install dependencies
 pip install -r requirements.txt

--- a/agents/openai-agents/README.md
+++ b/agents/openai-agents/README.md
@@ -22,8 +22,8 @@ This quickstart demonstrates how to run an OpenAI Agents SDK agent as a durable 
 cd openai-agents
 
 # Create and activate virtual environment
-python -m venv venv
-source venv/bin/activate  # On macOS/Linux
+python -m venv .venv
+source .venv/bin/activate  # On macOS/Linux
 
 # Install dependencies
 pip install -r requirements.txt

--- a/agents/strands/README.md
+++ b/agents/strands/README.md
@@ -22,8 +22,8 @@ This quickstart demonstrates how to run a Strands agent as a durable Dapr Workfl
 cd strands
 
 # Create and activate virtual environment
-python -m venv venv
-source venv/bin/activate  # On macOS/Linux
+python -m venv .venv
+source .venv/bin/activate  # On macOS/Linux
 
 # Install dependencies
 pip install -r requirements.txt


### PR DESCRIPTION
Use .venv instead of venv to align with the docs.
And fix /run to /agent/run endpoint.