### PR TITLE
fix: readme

### DIFF
--- a/agents/dapr-agents/orchestrator/README.md
+++ b/agents/dapr-agents/orchestrator/README.md
@@ -76,7 +76,7 @@ This starts all agents on ports 8001-8008:
 Once all agents are running, send a task to the orchestrator:
 
 ```bash
-curl -i -X POST http://localhost:8004/run \
+curl -i -X POST http://localhost:8004/agent/run \
   -H "Content-Type: application/json" \
   -d '{"task": "Plan a company offsite in Austin for 50 people"}'
 ```


### PR DESCRIPTION
the path is wrong in this quickstart
```
❯ curl -i -X POST http://localhost:8004/run \
  -H "Content-Type: application/json" \
  -d '{"task": "Plan a company offsite in Austin for 50 people"}'

HTTP/1.1 404 Not Found
date: Wed, 15 Apr 2026 00:09:22 GMT
server: uvicorn
content-length: 22
content-type: application/json

{"detail":"Not Found"}%
```