### PR TITLE
fix: serialize workflow status response as plain dict

### DIFF
--- a/workflow/python/main.py
+++ b/workflow/python/main.py
@@ -81,7 +81,16 @@ def get_workflow_status(instance_id: str):
             return Response(status_code=204)
         logger.info(f"Retrieved workflow status for {instance_id}.")
         logger.info(f"Workflow Runtime Status is: {state.runtime_status}")
-        return state
+        status_str = str(state.runtime_status)
+        return {
+            "exists": True,
+            "isWorkflowRunning": "RUNNING" in status_str,
+            "isWorkflowCompleted": "COMPLETED" in status_str,
+            "createdAt": state.created_at.isoformat() if state.created_at else None,
+            "lastUpdatedAt": state.last_updated_at.isoformat() if state.last_updated_at else None,
+            "runtimeStatus": state.runtime_status.value if hasattr(state.runtime_status, "value") else state.runtime_status,
+            "failureDetails": state.failure_details,
+        }
     except Exception as e:
         logger.error(f"Error occurred while getting the status of the workflow: {instance_id}. Exception: {e}")
         raise HTTPException(status_code=500, detail=str(e))


### PR DESCRIPTION
While going through the Workflow Quickstart (Python), the response from `/workflow/status/$INSTANCE_ID` was:
```
{    
      "instance_id":"...",
      "name":"...",                                                                                                                      
      "runtime_status":1,                                                                                                                                      
      "created_at":"<DATE_TIME>",
      "last_updated_at":"<DATE_TIME>",
      "serialized_input":"...",
      "serialized_output":"...", 
      "serialized_custom_status":null,                                                                                                                         
      "failure_details":null                                                                                                                                   
  }
```

which is different from what's expected according to the docs:
``` 
{
    "exists":true,
    "isWorkflowRunning":false,
    "isWorkflowCompleted":true,
    "createdAt":"<DATE_TIME>",
    "lastUpdatedAt":"<DATE_TIME>",
    "runtimeStatus":1,
    "failureDetails":null
}                                                               
```

It seems the endpoint was returning the raw `WorkflowState` SDK object, which I think FastAPI can't cleanly serialize. This fix extracts the fields into a plain dict.  