### PR TITLE
feat: quickstart feedback for langgraph wf enterprise identity

### DIFF
--- a/agents/langgraph/enterprise-identity/workflow-durability/README.md
+++ b/agents/langgraph/enterprise-identity/workflow-durability/README.md
@@ -27,10 +27,28 @@ erases records on request.
   makes the identity available to the workflow, and performs the OBO exchange for
   downstream MCP calls. Your graph code only declares `OAuthConfig` and
   `HITLConfig`.
-- **Same `OAuthConfig` type as the sync-path RFC** ([AI-702](https://linear.app/diagrid/issue/AI-702),
-  [`../service-invocation/`](../service-invocation/)). Whether an agent runs
+- **Same `OAuthConfig` type as the sync-path RFC**
+  ([`../service-invocation/`](../service-invocation/)). Whether an agent runs
   vanilla (sync) or under the workflow runner (this example), inbound identity is
   configured the same way — this is the unification story we're validating.
+
+### Plugin registration
+
+Identity behavior is registered as **plugins** that wrap the configs. Each config
+is wrapped in its plugin (`OAuthPlugin(oauth)`, `HITLPlugin(hitl)`) and passed as
+a list. The list construction is identical across all three RFC quickstarts —
+only the mount point differs:
+
+| Quickstart | Runtime | How the plugin list mounts |
+|------------|---------|----------------------------|
+| [`../service-invocation/`](../service-invocation/) | vanilla LangGraph, sync | `plugins=[...]` on the runner |
+| **`workflow-durability/` (this one)** | LangGraph + `DaprWorkflowGraphRunner` | `plugins=[...]` on the runner |
+| dapr-agents raw | `DurableAgent` (OSS-clean) | `lifecycle_dispatcher=PluginRegistry([...])` |
+
+The two workflow paths (this one and the dapr-agents raw quickstart) take the
+exact same `[OAuthPlugin(oauth), HITLPlugin(hitl)]` list. The mount kwarg differs
+only because `DurableAgent` is OSS-clean and can't take a `plugins=` kwarg
+directly.
 
 ## Prerequisites
 
@@ -158,4 +176,4 @@ Send `{"approved": false, ...}` to reject the deletion instead.
 ## Related
 
 - Sync-path counterpart (vanilla LangGraph, no workflow runner):
-  [`../service-invocation/`](../service-invocation/) — [AI-702](https://linear.app/diagrid/issue/AI-702)
+  [`../service-invocation/`](../service-invocation/)

--- a/agents/langgraph/enterprise-identity/workflow-durability/README.md
+++ b/agents/langgraph/enterprise-identity/workflow-durability/README.md
@@ -1,0 +1,161 @@
+# LangGraph + Enterprise Identity — Workflow (Durability) Path
+
+A **Customer Operations Agent** built with LangGraph and run as a durable Dapr
+Workflow via python-ai's `DaprWorkflowGraphRunner`. It answers questions about
+customers by reading Salesforce through an MCP tool, and — with human approval —
+erases records on request.
+
+## What this quickstart demonstrates
+
+- **Durable workflow-backed agent**: each graph node runs under
+  `DaprWorkflowGraphRunner`, so progress is checkpointed and survives
+  crashes and restarts.
+- **User identity in, on the agent's behalf out**: the caller's verified user
+  identity is exchanged (OBO) for a downstream token scoped to the target MCP
+  server. The exchange happens in the sidecar — no token handling in app code.
+- **Human-in-the-loop (HITL)**: the destructive `delete_customer` tool durably
+  **pauses** the workflow until an approver holding the `approver.dev` scope
+  resolves the request, then **resumes** from where it paused. The sync path
+  cannot hold a pause open — this is unique to the workflow path.
+- **Full audit chain**: the user → agent → tool/MCP hops are recorded in signed
+  workflow history, so the entire lineage is auditable after the fact.
+
+## Identity model
+
+- **Developers building agents never touch the `X-Diagrid-User-Token` header.**
+  The runner handles inbound identity internally: it verifies the caller's token,
+  makes the identity available to the workflow, and performs the OBO exchange for
+  downstream MCP calls. Your graph code only declares `OAuthConfig` and
+  `HITLConfig`.
+- **Same `OAuthConfig` type as the sync-path RFC** ([AI-702](https://linear.app/diagrid/issue/AI-702),
+  [`../service-invocation/`](../service-invocation/)). Whether an agent runs
+  vanilla (sync) or under the workflow runner (this example), inbound identity is
+  configured the same way — this is the unification story we're validating.
+
+## Prerequisites
+
+1. [Diagrid CLI](https://docs.diagrid.io/catalyst/references/cli-reference/overview) installed
+2. [Python 3.10+](https://www.python.org/downloads/)
+3. An [OpenAI API key](https://platform.openai.com/api-keys)
+
+## Setup
+
+**macOS/Linux (bash/zsh):**
+
+```bash
+cd agents/langgraph/enterprise-identity/workflow-durability
+
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+**Windows (PowerShell):**
+
+```powershell
+cd agents/langgraph/enterprise-identity/workflow-durability
+
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+pip install -r requirements.txt
+```
+
+### Set your API key
+
+**macOS/Linux (bash/zsh):**
+
+```bash
+export OPENAI_API_KEY="your-key-here"
+```
+
+**Windows (PowerShell):**
+
+```powershell
+$env:OPENAI_API_KEY = "your-key-here"
+```
+
+## Running the quickstart
+
+### 1. Deploy and run
+
+```bash
+diagrid login
+diagrid dev run -f dev.yaml
+```
+
+The agent's app ID is `customer-ops-agent`.
+
+### 2. Invoke the agent
+
+**Primary — CLI (no header handling):**
+
+The CLI adds the `X-Diagrid-User-Token` header automatically from
+`~/.diagrid/creds` after `diagrid login`. Note the dotted `<appid>.<method>`
+notation for the target.
+
+```bash
+diagrid call invoke post customer-ops-agent.invoke \
+  --app-id <caller-appid> \
+  --data '{"prompt": "List customers in the EMEA region"}'
+```
+
+**Alternative — raw HTTP (for debugging):**
+
+Here you set the user token yourself. This is the header the CLI otherwise adds
+for you; app code never reads or sets it.
+
+```bash
+curl -X POST http://localhost:3500/v1.0/invoke/customer-ops-agent/method/invoke \
+  -H "X-Diagrid-User-Token: Bearer <your JWT>" \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "List customers in the EMEA region"}'
+```
+
+**Without a user token (expect `401`):**
+
+The runner's inbound dependency rejects the call when no user token is present.
+
+```bash
+curl -X POST http://localhost:3500/v1.0/invoke/customer-ops-agent/method/invoke \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "List customers in the EMEA region"}'
+```
+
+### 3. Approve a human-in-the-loop request
+
+Ask the agent to delete a record. The `delete_customer` tool returns
+`RequireApproval`, so the workflow **suspends** and the response includes the
+workflow instance ID and an approval request ID.
+
+```bash
+diagrid call invoke post customer-ops-agent.invoke \
+  --app-id <caller-appid> \
+  --data '{"prompt": "Delete customer record 001XX000ABCDEFG"}'
+```
+
+An approver holding the `approver.dev` scope resumes the workflow by raising the
+approval-response event:
+
+```bash
+diagrid call workflow raiseevent \
+  --app-id customer-ops-agent \
+  --instance-id <workflow-instance-id-from-response> \
+  --event approval-response-<approval-request-id> \
+  --data '{"approved": true, "approver_token": "<approver JWT>"}'
+```
+
+Send `{"approved": false, ...}` to reject the deletion instead.
+
+**Two identities are in play here:**
+
+- The inbound `X-Diagrid-User-Token` carries the **original caller's** identity —
+  who asked the agent to act. This is what OBO propagates to Salesforce.
+- The `approver_token` in the `raiseevent` body carries the **approver's**
+  identity — who authorized the destructive action. It's a different principal,
+  checked against the tool's `required_approver_scopes` (`approver.dev`), and
+  recorded separately in the audit chain.
+
+## Related
+
+- Sync-path counterpart (vanilla LangGraph, no workflow runner):
+  [`../service-invocation/`](../service-invocation/) — [AI-702](https://linear.app/diagrid/issue/AI-702)

--- a/agents/langgraph/enterprise-identity/workflow-durability/dev.yaml
+++ b/agents/langgraph/enterprise-identity/workflow-durability/dev.yaml
@@ -1,0 +1,13 @@
+version: 1
+common:
+  appLogDestination: console
+  enableAppHealthCheck: false
+  logLevel: info
+apps:
+  - appID: customer-ops-agent
+    appDirPath: ./
+    appPort: 8005
+    appProtocol: http
+    command: ["python", "main.py"]
+    env:
+      APP_PORT: "8005"

--- a/agents/langgraph/enterprise-identity/workflow-durability/main.py
+++ b/agents/langgraph/enterprise-identity/workflow-durability/main.py
@@ -1,0 +1,89 @@
+import os
+
+from langchain_core.messages import HumanMessage, ToolMessage
+from langchain_core.tools import tool
+from langgraph.graph import StateGraph, START, MessagesState
+from langchain_openai import ChatOpenAI
+from dapr.clients import DaprClient
+
+from diagrid.identity import OAuthConfig
+from diagrid.agent.identity import HITLConfig
+from diagrid.agent.langgraph import DaprWorkflowGraphRunner
+from dapr_agents.hooks import RequireApproval
+
+APP_PORT = int(os.environ.get("APP_PORT", "8005"))
+AGENT_SERVICE = "agent-service"
+SALESFORCE_MCP = "salesforce-mcp"
+APPROVER_SCOPE = "approver.dev"
+
+
+@tool
+def query_customers(soql: str) -> str:
+    """Read Salesforce records matching a SOQL query."""
+    with DaprClient() as d:
+        resp = d.invoke_method(
+            AGENT_SERVICE,
+            f"v1/diagrid/mcp/{SALESFORCE_MCP}/tools/query",
+            data={"soql": soql},
+        )
+    return resp.text()
+
+
+@tool
+def delete_customer(record_id: str) -> str:
+    """Delete a Salesforce customer record. Requires human approval before it runs."""
+    return RequireApproval(
+        required_approver_scopes={APPROVER_SCOPE},
+        reason=f"Delete customer records ({record_id}) — GDPR erasure flow",
+    )
+
+
+tools = [query_customers, delete_customer]
+tools_by_name = {t.name: t for t in tools}
+model = ChatOpenAI(model="gpt-4.1-2025-04-14").bind_tools(tools)
+
+
+def call_model(state: MessagesState) -> dict:
+    response = model.invoke(state["messages"])
+    return {"messages": [response]}
+
+
+def call_tools(state: MessagesState) -> dict:
+    last_message = state["messages"][-1]
+    results = []
+    for tc in last_message.tool_calls:
+        result = tools_by_name[tc["name"]].invoke(tc["args"])
+        results.append(ToolMessage(content=str(result), tool_call_id=tc["id"]))
+    return {"messages": results}
+
+
+def should_use_tools(state: MessagesState) -> str:
+    last_message = state["messages"][-1]
+    if hasattr(last_message, "tool_calls") and last_message.tool_calls:
+        return "tools"
+    return "__end__"
+
+
+graph = StateGraph(MessagesState)
+graph.add_node("agent", call_model)
+graph.add_node("tools", call_tools)
+graph.add_edge(START, "agent")
+graph.add_conditional_edges("agent", should_use_tools)
+graph.add_edge("tools", "agent")
+
+oauth = OAuthConfig(scopes={"agent.invoke"})
+hitl = HITLConfig(required_approver_scopes={APPROVER_SCOPE})
+
+runner = DaprWorkflowGraphRunner(
+    graph=graph.compile(),
+    name="customer-ops",
+    role="Customer Operations Agent",
+    goal="Answer questions about customers and, with approval, erase records on request.",
+    oauth=oauth,
+    hitl=hitl,
+)
+
+runner.serve(
+    port=APP_PORT,
+    input_mapper=lambda req: {"messages": [HumanMessage(content=req["prompt"])]},
+)

--- a/agents/langgraph/enterprise-identity/workflow-durability/main.py
+++ b/agents/langgraph/enterprise-identity/workflow-durability/main.py
@@ -8,6 +8,7 @@ from dapr.clients import DaprClient
 
 from diagrid.identity import OAuthConfig
 from diagrid.agent.identity import HITLConfig
+from diagrid.agent.plugins import OAuthPlugin, HITLPlugin
 from diagrid.agent.langgraph import DaprWorkflowGraphRunner
 from dapr_agents.hooks import RequireApproval
 
@@ -79,8 +80,7 @@ runner = DaprWorkflowGraphRunner(
     name="customer-ops",
     role="Customer Operations Agent",
     goal="Answer questions about customers and, with approval, erase records on request.",
-    oauth=oauth,
-    hitl=hitl,
+    plugins=[OAuthPlugin(oauth), HITLPlugin(hitl)],
 )
 
 runner.serve(

--- a/agents/langgraph/enterprise-identity/workflow-durability/requirements.txt
+++ b/agents/langgraph/enterprise-identity/workflow-durability/requirements.txt
@@ -1,0 +1,6 @@
+diagrid[langgraph]==0.4.2
+diagrid-identity
+langchain-openai==1.2.1
+dapr==1.15.0
+fastapi==0.136.1
+uvicorn[standard]==0.46.0

--- a/agents/langgraph/enterprise-identity/workflow-durability/test.http
+++ b/agents/langgraph/enterprise-identity/workflow-durability/test.http
@@ -1,0 +1,39 @@
+@userToken = REPLACE_WITH_USER_JWT
+@approverToken = REPLACE_WITH_APPROVER_JWT
+@instanceId = REPLACE_WITH_WORKFLOW_INSTANCE_ID
+@approvalId = REPLACE_WITH_APPROVAL_REQUEST_ID
+
+### Query customers (OBO-propagated MCP read)
+POST http://localhost:3500/v1.0/invoke/customer-ops-agent/method/invoke
+Content-Type: application/json
+X-Diagrid-User-Token: Bearer {{userToken}}
+
+{
+    "prompt": "List customers in the EMEA region"
+}
+
+### Without a user token — expect 401 from the runner's inbound dependency
+POST http://localhost:3500/v1.0/invoke/customer-ops-agent/method/invoke
+Content-Type: application/json
+
+{
+    "prompt": "List customers in the EMEA region"
+}
+
+### Request a deletion (returns a pending HITL approval + workflow instance ID)
+POST http://localhost:3500/v1.0/invoke/customer-ops-agent/method/invoke
+Content-Type: application/json
+X-Diagrid-User-Token: Bearer {{userToken}}
+
+{
+    "prompt": "Delete customer record 001XX000ABCDEFG"
+}
+
+### Approve the pending deletion (approver identity carried in the event body)
+POST http://localhost:3500/v1.0/workflows/dapr/{{instanceId}}/raiseEvent/approval-response-{{approvalId}}
+Content-Type: application/json
+
+{
+    "approved": true,
+    "approver_token": "{{approverToken}}"
+}


### PR DESCRIPTION
DO NOT MERGE AS THIS WILL NOT RUN. Just for feedback :) 

https://linear.app/diagrid/issue/AI-703/rfc-quickstart-pr-agentslanggraphenterprise-identityworkflow

I am using PRs as a means of getting feedback on the end UX for the agent enterprise identity for the plugins work. This PR is for the langgrraph agent using our workflow runner + Oauth plugin + HITL plugin. OBO is done transparently in the sidecar. 

You will see the same classes for OAuthConfig and HITLConfig where applicable. 

What I want feedback on:

- Runner kwargs: runner(oauth=..., hitl=...) vs runner(plugins=[...]) — which is more discoverable? are we ok with my plugins setup?
- Same OAuthConfig type as sync PR — does the unification actually feel unified? given the HTTP only route there are no plugins, so i made the config class called OAuthConfig to help unify things better.
- HITLConfig import from diagrid.agent.identity (workflow-only) — clean separation, or annoying? Bc putting it under an identity package feels and looks nice given this is about trust/identity; however, it means another import for users.
- Is RequireApproval(...) inside a tool the right HITL trigger? Please hold here and reminder to myself that I need to circle back on this one tomorrow @sicoyle 
Sub-agent workflow dispatch — auth propagation should be implicit (via PropagateLineage) or explicit?
