### PR TITLE
feat: add langgraph no wf quickstart for feedback

### DIFF
--- a/agents/langgraph/enterprise-identity/service-invocation/README.md
+++ b/agents/langgraph/enterprise-identity/service-invocation/README.md
@@ -1,0 +1,107 @@
+# Enterprise Identity — Vanilla LangGraph over Service Invocation
+
+Run a **vanilla LangGraph agent** under a user identity that can act on the
+user's behalf — with **no Diagrid workflow runner**. This is a plain FastAPI app
+that hosts a LangGraph graph, adds the Diagrid identity middleware, and calls an
+MCP tool through the Diagrid sidecar on behalf of the calling user.
+
+## What this quickstart demonstrates
+
+- **No Diagrid workflow runner** — a plain FastAPI app hosting LangGraph. The
+  graph itself has no Diagrid awareness.
+- **User identity flows in via `X-Diagrid-User-Token`** — the sidecar populates
+  this header, and `OAuthMiddleware`
+  reads the delivered claims onto `request.state.diagrid_user`.
+- **OBO to MCP is transparent** — the on-behalf-of exchange happens in the
+  sidecar. Nothing the developer does beyond calling the sidecar
+  (`invoke_method`) is identity-aware; the user token propagates automatically to
+  the MCP tool call.
+- **HITL is not available in this path** — human-in-the-loop requires the durable
+  workflow runner. See [`workflow-durability/`](../../workflow-durability/) for that.
+
+## Identity setup
+
+Diagrid identity is wired in three steps, all in [`main.py`](./main.py):
+
+1. Construct an `OAuthConfig` with the scopes the agent requires.
+2. Register `OAuthMiddleware` on the FastAPI app with that config.
+3. Read the authenticated user off `request.state.diagrid_user` inside any
+   endpoint — the middleware populates it from the sidecar-delivered claims.
+
+## Prerequisites
+
+1. [Diagrid CLI](https://docs.diagrid.io/catalyst/references/cli-reference/overview) installed
+2. [Python 3.10+](https://www.python.org/downloads/)
+3. An [OpenAI API key](https://platform.openai.com/api-keys)
+
+## Setup
+
+```bash
+cd agents/langgraph/enterprise-identity/service-invocation
+
+python -m venv .venv
+source .venv/bin/activate
+
+pip install -r requirements.txt
+
+export OPENAI_API_KEY="your-key-here"
+```
+
+## Running the quickstart
+
+```bash
+diagrid login
+diagrid dev run -f dev.yaml
+```
+
+## Who handles the user token
+
+The user identity travels on the `X-Diagrid-User-Token` header:**
+
+- **Developers building agents** trigger their agent via HTTP setting the following header: `X-Diagrid-User-Token`.
+  `OAuthMiddleware` reads it and populates `request.state.diagrid_user`.
+- **Users invoking agents** — via `diagrid call invoke`, the UI, or an
+  SDK — do not touch it either. The tooling sets it automatically from your
+  credentials after `diagrid login`.
+
+The header only appears explicitly in the raw `curl` example below, which is the
+fallback for debugging or calling from a client that isn't Diagrid tooling.
+
+## Invoking the agent
+
+From another terminal, once the app is running.
+
+### Primary — Diagrid CLI (no header handling)
+
+The CLI adds `X-Diagrid-User-Token` automatically from `~/.diagrid/creds` after
+`diagrid login`. Note the dotted `<appid>.<method>` notation:
+
+```bash
+diagrid call invoke post langgraph-identity-agent.invoke \
+  --app-id <caller-appid> \
+  --data '{"prompt": "How many open opportunities does ACME have in Salesforce?"}'
+```
+
+### Alternative — raw HTTP (debugging or non-CLI callers)
+
+Only here does the caller set the header itself:
+
+```bash
+curl -X POST http://localhost:3500/v1.0/invoke/langgraph-identity-agent/method/invoke \
+  -H "X-Diagrid-User-Token: Bearer <your JWT>" \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "How many open opportunities does ACME have in Salesforce?"}'
+```
+
+### Negative — no header (expect 401)
+
+```bash
+curl -X POST http://localhost:3500/v1.0/invoke/langgraph-identity-agent/method/invoke \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "How many open opportunities does ACME have in Salesforce?"}'
+```
+
+Expected response: `401` with code `oauth.missing_caller_claims`.
+
+The user identity delivered on the inbound request propagates through the sidecar
+to the Salesforce MCP tool call — no token handling in the graph.

--- a/agents/langgraph/enterprise-identity/service-invocation/dev.yaml
+++ b/agents/langgraph/enterprise-identity/service-invocation/dev.yaml
@@ -1,0 +1,13 @@
+version: 1
+common:
+  appLogDestination: console
+  enableAppHealthCheck: false
+  logLevel: info
+apps:
+  - appID: langgraph-identity-agent
+    appDirPath: ./
+    appPort: 8005
+    appProtocol: http
+    command: ["python", "main.py"]
+    env:
+      APP_PORT: "8005"

--- a/agents/langgraph/enterprise-identity/service-invocation/main.py
+++ b/agents/langgraph/enterprise-identity/service-invocation/main.py
@@ -1,0 +1,92 @@
+import logging
+import os
+
+logging.basicConfig(level=logging.INFO)
+
+from fastapi import FastAPI, Request
+from langchain_core.messages import HumanMessage, ToolMessage
+from langchain_core.tools import tool
+from langchain_openai import ChatOpenAI
+from langgraph.graph import START, MessagesState, StateGraph
+from dapr.clients import DaprClient
+from diagrid.identity import OAuthConfig
+from diagrid.identity.asgi import OAuthMiddleware
+
+AGENT_SERVICE_APP_ID = "agent-service"
+SALESFORCE_QUERY_METHOD = "v1/diagrid/mcp/salesforce-mcp/tools/query"
+
+model = ChatOpenAI(model="gpt-4.1-2025-04-14")
+
+
+@tool
+def query_salesforce(soql: str) -> str:
+    """Query Salesforce on behalf of the calling user via the Diagrid sidecar.
+
+    The sidecar performs the on-behalf-of (OBO) token exchange transparently;
+    the user identity delivered on the inbound request propagates to the MCP
+    tool call without any token handling in the graph.
+    """
+    with DaprClient() as d:
+        response = d.invoke_method(
+            AGENT_SERVICE_APP_ID,
+            SALESFORCE_QUERY_METHOD,
+            data={"soql": soql},
+        )
+        return response.text()
+
+
+tools = [query_salesforce]
+tools_by_name = {t.name: t for t in tools}
+model_with_tools = model.bind_tools(tools)
+
+
+def call_llm(state: MessagesState) -> dict:
+    response = model_with_tools.invoke(state["messages"])
+    return {"messages": [response]}
+
+
+def call_mcp_tool(state: MessagesState) -> dict:
+    last_message = state["messages"][-1]
+    results = []
+    for tc in last_message.tool_calls:
+        result = tools_by_name[tc["name"]].invoke(tc["args"])
+        results.append(ToolMessage(content=str(result), tool_call_id=tc["id"]))
+    return {"messages": results}
+
+
+def should_use_tools(state: MessagesState) -> str:
+    last_message = state["messages"][-1]
+    if hasattr(last_message, "tool_calls") and last_message.tool_calls:
+        return "tools"
+    return "__end__"
+
+
+# Build a normal LangGraph — no Diagrid awareness in the graph itself.
+graph = StateGraph(MessagesState)
+graph.add_node("agent", call_llm)
+graph.add_node("tools", call_mcp_tool)
+graph.add_edge(START, "agent")
+graph.add_conditional_edges("agent", should_use_tools)
+graph.add_edge("tools", "agent")
+compiled = graph.compile()
+
+# ---- Diagrid identity setup — 3 lines ----
+oauth = OAuthConfig(scopes={"agent.invoke"})
+app = FastAPI()
+app.add_middleware(OAuthMiddleware, config=oauth)
+
+
+@app.post("/invoke")
+def invoke(request: Request, body: dict):
+    user = request.state.diagrid_user  # populated by OAuthMiddleware
+    result = compiled.invoke(
+        {"messages": [HumanMessage(content=body["prompt"])]},
+        config={"configurable": {"user_subject": user.subject}},
+    )
+    return {"messages": [m.content for m in result["messages"]]}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="127.0.0.1", port=int(os.environ.get("APP_PORT", "8005")))

--- a/agents/langgraph/enterprise-identity/service-invocation/requirements.txt
+++ b/agents/langgraph/enterprise-identity/service-invocation/requirements.txt
@@ -1,0 +1,6 @@
+diagrid-identity
+langchain-openai==1.2.1
+langgraph==0.6.7
+fastapi==0.136.1
+uvicorn[standard]==0.46.0
+dapr==1.16.0


### PR DESCRIPTION
DO NOT MERGE AS THIS WILL NOT RUN. Just for feedback :)

https://linear.app/diagrid/issue/AI-702/rfc-quickstart-pr-agentslanggraphenterprise-identityservice-invocation

I am using PRs as a means of getting feedback on the end UX for the agent enterprise identity for the plugins work. This PR is for the langgrraph agent with absolutely no workflows using service invocation only + Oauth plugin + NOOOOO HITL plugin as that is a wf only feature. OBO is done transparently in the sidecar.

You will see the same classes for OAuthConfig and HITLConfig where applicable.

What I want feedback on:

- OAuthConfig — right name? Or OAuthPolicy / IdentityConfig?
- OAuthMiddleware — right name? Or IdentityMiddleware?
- request.state.diagrid_user — right accessor? Or get_user(request) / dep-only pattern?
- Middleware vs per-endpoint dep — which should be primary in docs?
- exclude_paths= kwarg — needed, or should devs use sub-routers?

Does this shape work if the developer's framework isn't FastAPI? TBD @sicoyle to look at this tomorrow too 😅 