### PR TITLE
feat: add dapr agents quickstart for feedback

### DIFF
--- a/agents/dapr-agents/enterprise-identity/Dockerfile
+++ b/agents/dapr-agents/enterprise-identity/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.12-slim
+WORKDIR /app
+EXPOSE 8001
+COPY requirements.txt .
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential \
+    && pip install -r requirements.txt \
+    && apt-get purge -y --auto-remove build-essential \
+    && rm -rf /var/lib/apt/lists/*
+COPY . .
+CMD ["python", "main.py"]

--- a/agents/dapr-agents/enterprise-identity/README.md
+++ b/agents/dapr-agents/enterprise-identity/README.md
@@ -1,0 +1,146 @@
+# Enterprise Identity — Dapr Agents `DurableAgent`
+
+This quickstart shows how to give a **raw [Dapr Agents](https://github.com/dapr/dapr-agents)
+`DurableAgent`** an enterprise identity: it runs under the calling user's identity,
+calls downstream tools **on behalf of (OBO)** that user, and gates destructive
+operations behind **human-in-the-loop (HITL)** approval.
+
+## How it fits with the other identity quickstarts
+
+The same identity primitives are available across levels of framework abstraction.
+The identity *config* is unified — only the *dispatch* differs.
+
+| Quickstart | Framework | Identity surface | HITL |
+|------------|-----------|------------------|------|
+| [`langgraph/enterprise-identity/service-invocation/`](../../langgraph/enterprise-identity/service-invocation/) | Vanilla LangGraph | `OAuthConfig` via helper library | ✗ (sync path) |
+| [`langgraph/enterprise-identity/workflow-durability/`](../../langgraph/enterprise-identity/workflow-durability/) | LangGraph + `DaprWorkflowGraphRunner` | `OAuthConfig` + `HITLConfig` via runner kwargs | ✓ (durable pause/resume) |
+| **`dapr-agents/enterprise-identity/`** (this one) | Raw Dapr Agents `DurableAgent` | `OAuthConfig` + `HITLConfig` via `PluginRegistry` | ✓ (durable pause/resume) |
+
+## What this demonstrates
+
+- **Raw `DurableAgent`**.
+- **Unified identity config** — the `OAuthConfig` and `HITLConfig` types are the same
+  ones used by the LangGraph quickstarts.
+- **`Plugin` protocol + `PluginRegistry`** — lifecycle plugins run as a chain, so you
+  can add your own plugins alongside `OAuthPlugin` / `HITLPlugin`.
+- **Transparent OBO via the sidecar** — the agent calls downstream MCP tools under the
+  calling user's identity; the sidecar performs the token exchange. No token handling
+  in application code.
+- **HITL** — the `delete_account` tool returns `RequireApproval`, and `HITLPlugin` gates
+  resumption on a scoped approver, backed by durable workflow pause/resume.
+
+## Identity setup
+
+Identity is wired in [`main.py`](./main.py): build an `OAuthConfig` and a `HITLConfig`,
+then pass `lifecycle_dispatcher=PluginRegistry([OAuthPlugin(oauth), HITLPlugin(hitl)])`
+to the `DurableAgent`. `OAuthPlugin` runs the agent under the calling user's identity;
+`HITLPlugin` gates any tool that returns `RequireApproval` on a scoped approver.
+
+## Prerequisites
+
+1. [Diagrid CLI](https://docs.diagrid.io/catalyst/references/cli-reference/overview) installed
+2. [Python 3.10+](https://www.python.org/downloads/)
+3. An [OpenAI API key](https://platform.openai.com/api-keys)
+
+## Setup
+
+Inside the project directory, run the following commands:
+
+**macOS/Linux (bash/zsh):**
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+**Windows (PowerShell):**
+
+```powershell
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+pip install -r requirements.txt
+```
+
+### Configure the LLM provider
+
+Update `resources/llm-provider.yaml` with your OpenAI API key:
+
+```yaml
+metadata:
+  - name: key
+    value: "YOUR_OPENAI_API_KEY"
+```
+
+## Running the quickstart
+
+### 1. Deploy and run on Catalyst
+
+```bash
+diagrid login
+diagrid dev run -f dev.yaml --project salesforce-agent
+```
+
+### 2. Invoke the agent (recommended)
+
+Every inbound call must carry the `X-Diagrid-User-Token` header — that is what the
+sidecar's inbound auth middleware reads to establish the user identity, and what
+`OAuthPlugin` then enforces. The `diagrid` CLI attaches it automatically from
+`~/.diagrid/creds` after `diagrid login`, so no header handling is needed:
+
+```bash
+diagrid call invoke post salesforce-agent.invoke \
+  --app-id <caller-app-id> \
+  --data '{"prompt": "What is the name and owner of account 001XX000ABC?"}'
+```
+
+Note the dotted `<app-id>.<method>` notation. The agent runs `query_account` under the
+calling user's identity; the sidecar performs the OBO token exchange for any downstream
+call transparently.
+
+### 3. Invoke over raw HTTP (debugging)
+
+To call the sidecar directly, supply the header yourself:
+
+```bash
+curl -X POST http://localhost:3500/v1.0/invoke/salesforce-agent/method/invoke \
+  -H "X-Diagrid-User-Token: Bearer <your-jwt>" \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "What is the name and owner of account 001XX000ABC?"}'
+```
+
+Without the header, the sidecar skips auth, the agent sees no user identity, and
+`OAuthPlugin` rejects the request:
+
+```bash
+curl -X POST http://localhost:3500/v1.0/invoke/salesforce-agent/method/invoke \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "What is the name and owner of account 001XX000ABC?"}'
+```
+
+### 4. Approve a HITL request
+
+Asking the agent to delete an account makes `delete_account` return `RequireApproval`,
+so `HITLPlugin` pauses the durable workflow:
+
+```bash
+diagrid call invoke post salesforce-agent.invoke \
+  --app-id <caller-app-id> \
+  --data '{"prompt": "Delete account 001XX000ABC"}'
+```
+
+The paused response carries a workflow instance ID and an approval request ID. Resume
+it by raising the approval event with a token from an approver holding the `approver.dev`
+scope:
+
+```bash
+diagrid call workflow raiseevent \
+  --app-id salesforce-agent \
+  --instance-id <workflow-instance-id-from-response> \
+  --event approval-response-<approval-request-id> \
+  --data '{"approved": true, "approver_token": "<approver-jwt>"}'
+```
+
+You can also drive the invoke requests from [`test.http`](./test.http) with the VS Code
+[REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client)
+extension.

--- a/agents/dapr-agents/enterprise-identity/dev.yaml
+++ b/agents/dapr-agents/enterprise-identity/dev.yaml
@@ -1,0 +1,12 @@
+version: 1
+common:
+  appLogDestination: console
+  resourcesPath: ./resources
+  enableAppHealthCheck: false
+  logLevel: info
+apps:
+  - appID: salesforce-agent
+    appDirPath: ./
+    appPort: 8001
+    appProtocol: http
+    command: ["python", "main.py"]

--- a/agents/dapr-agents/enterprise-identity/main.py
+++ b/agents/dapr-agents/enterprise-identity/main.py
@@ -1,0 +1,96 @@
+import logging
+import os
+from typing import List
+
+from pydantic import BaseModel, Field
+from dapr_agents import tool, DurableAgent
+from dapr_agents.llm import DaprChatClient
+from dapr_agents.hooks import RequireApproval
+
+from dapr_agents.agents.configs import (
+    AgentMemoryConfig,
+    AgentPubSubConfig,
+    AgentRegistryConfig,
+    AgentStateConfig,
+)
+from dapr_agents.memory import ConversationDaprStateMemory
+from dapr_agents.storage.daprstores.stateservice import StateStoreService
+
+from diagrid.identity import OAuthConfig
+from diagrid.agent.identity import HITLConfig
+from diagrid.agent.plugins import PluginRegistry, OAuthPlugin, HITLPlugin
+
+
+class AccountQuery(BaseModel):
+    account_id: str = Field(description="Salesforce account ID to look up")
+
+
+class AccountRecord(BaseModel):
+    account_id: str = Field(description="Salesforce account ID")
+    name: str = Field(description="Account name")
+    owner: str = Field(description="Account owner")
+
+
+class DeleteAccountSchema(BaseModel):
+    account_id: str = Field(description="Salesforce account ID to delete")
+
+
+@tool(args_model=AccountQuery)
+def query_account(account_id: str) -> AccountRecord:
+    """Look up a Salesforce account by ID on behalf of the calling user."""
+    return AccountRecord(account_id=account_id, name="Acme Corp", owner="user@acme.example")
+
+
+@tool(args_model=DeleteAccountSchema)
+def delete_account(account_id: str) -> RequireApproval:
+    """Delete a Salesforce account. Gated by HITL — a scoped approver must sign off."""
+    return RequireApproval(
+        required_approver_scopes={"approver.dev"},
+        reason=f"Delete Salesforce account {account_id} — irreversible",
+    )
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+
+    oauth = OAuthConfig(scopes={"agent.invoke"})
+    hitl = HITLConfig(required_approver_scopes={"approver.dev"})
+
+    agent = DurableAgent(
+        name="salesforce-agent",
+        role="Answer customer questions using Salesforce data",
+        goal="Answer account questions and perform account operations on behalf of the calling user.",
+        instructions=[
+            "Use query_account to look up account details before answering questions.",
+            "Use delete_account only when explicitly asked to delete an account; it requires human approval.",
+        ],
+        tools=[query_account, delete_account],
+        llm=DaprChatClient(component_name="llm-provider"),
+        memory=AgentMemoryConfig(
+            store=ConversationDaprStateMemory(store_name="agent-workflow"),
+        ),
+        state=AgentStateConfig(
+            store=StateStoreService(store_name="agent-memory"),
+        ),
+        registry=AgentRegistryConfig(
+            store=StateStoreService(store_name="agent-registry"),
+        ),
+        pubsub=AgentPubSubConfig(
+            pubsub_name="agent-pubsub",
+            agent_topic="agents.salesforce.requests",
+            broadcast_topic="agents.broadcast",
+        ),
+        lifecycle_dispatcher=PluginRegistry([
+            OAuthPlugin(oauth),
+            HITLPlugin(hitl),
+        ]),
+    )
+
+    agent.as_service(port=int(os.environ.get("APP_PORT", "8001")))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        pass

--- a/agents/dapr-agents/enterprise-identity/requirements.txt
+++ b/agents/dapr-agents/enterprise-identity/requirements.txt
@@ -1,0 +1,3 @@
+dapr-agents==1.0.2
+diagrid-identity
+diagrid-agent

--- a/agents/dapr-agents/enterprise-identity/resources/agent-memory.yaml
+++ b/agents/dapr-agents/enterprise-identity/resources/agent-memory.yaml
@@ -1,0 +1,14 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: agent-memory
+spec:
+  type: state.redis
+  version: v1
+  metadata:
+  - name: redisHost
+    value: localhost:6379
+  - name: redisPassword
+    value: ""
+  - name: actorStateStore
+    value: "false"

--- a/agents/dapr-agents/enterprise-identity/resources/agent-pubsub.yaml
+++ b/agents/dapr-agents/enterprise-identity/resources/agent-pubsub.yaml
@@ -1,0 +1,16 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: agent-pubsub
+spec:
+  type: pubsub.redis
+  version: v1
+  metadata:
+    - name: redisHost
+      value: localhost:6379
+    - name: redisPassword
+      value: ""
+    - name: consumerID
+      value: "travel-planner-group"
+    - name: enableTLS
+      value: "false"

--- a/agents/dapr-agents/enterprise-identity/resources/agent-registry.yaml
+++ b/agents/dapr-agents/enterprise-identity/resources/agent-registry.yaml
@@ -1,0 +1,14 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: agent-registry
+spec:
+  type: state.redis
+  version: v1
+  metadata:
+  - name: redisHost
+    value: localhost:6379
+  - name: redisPassword
+    value: ""
+  - name: keyPrefix
+    value: none

--- a/agents/dapr-agents/enterprise-identity/resources/agent-wfstatestore.yaml
+++ b/agents/dapr-agents/enterprise-identity/resources/agent-wfstatestore.yaml
@@ -1,0 +1,14 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: agent-workflow
+spec:
+  type: state.redis
+  version: v1
+  metadata:
+  - name: redisHost
+    value: localhost:6379
+  - name: redisPassword
+    value: ""
+  - name: actorStateStore
+    value: "true"

--- a/agents/dapr-agents/enterprise-identity/resources/llm-provider.yaml
+++ b/agents/dapr-agents/enterprise-identity/resources/llm-provider.yaml
@@ -1,0 +1,12 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: llm-provider
+spec:
+  type: conversation.openai
+  version: v1
+  metadata:
+  - name: key
+    value: "{{OPENAI_API_KEY}}"
+  - name: model
+    value: gpt-4.1-2025-04-14

--- a/agents/dapr-agents/enterprise-identity/test.http
+++ b/agents/dapr-agents/enterprise-identity/test.http
@@ -1,0 +1,25 @@
+### Query an account (OBO — runs under the calling user's identity)
+POST http://localhost:3500/v1.0/invoke/salesforce-agent/method/invoke
+X-Diagrid-User-Token: Bearer <your-jwt>
+Content-Type: application/json
+
+{
+    "prompt": "What is the name and owner of account 001XX000ABC?"
+}
+
+### Delete an account (triggers HITL — HITLPlugin pauses for a scoped approver)
+POST http://localhost:3500/v1.0/invoke/salesforce-agent/method/invoke
+X-Diagrid-User-Token: Bearer <your-jwt>
+Content-Type: application/json
+
+{
+    "prompt": "Delete account 001XX000ABC"
+}
+
+### Rejected — no X-Diagrid-User-Token header, so OAuthPlugin denies the request
+POST http://localhost:3500/v1.0/invoke/salesforce-agent/method/invoke
+Content-Type: application/json
+
+{
+    "prompt": "What is the name and owner of account 001XX000ABC?"
+}


### PR DESCRIPTION
DO NOT MERGE AS THIS WILL NOT RUN. Just for feedback :)

https://linear.app/diagrid/issue/AI-704/rfc-quickstart-pr-agentsdapr-agentsenterprise-identity-dapr-agents

I am using PRs as a means of getting feedback on the end UX for the agent enterprise identity for the plugins work. This PR is for the dapr agent agentic workflow + Oauth plugin + HITL plugin. OBO is done transparently in the sidecar.

You will see the same classes for OAuthConfig and HITLConfig where applicable.

What I want feedback on:
- lifecycle_dispatcher=PluginRegistry([OAuthPlugin(oauth), HITLPlugin(hitl)]) — is this the right kwarg name + shape?
- Explicit OAuthPlugin(oauth) wrapping — good as is ?
- Should PluginRegistry accept configs directly (PluginRegistry(oauth=oauth, hitl=hitl)) as sugar?
- Where do custom Plugins go — extra_plugins=[...] or just append to the same list?