### PR TITLE
feat: Spring AI agent quickstarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Catalyst works with the following agent frameworks:
 | [LangGraph](agents/langgraph/) | Graph-based agent orchestration with conditional routing, made durable with Catalyst |
 | [Strands](agents/strands/) | Model-driven agent framework from AWS with tool use, made durable with Catalyst |
 | [Microsoft Agent Framework](agents/microsoft-dotnet/) | Enterprise agent framework from Microsoft, made durable with Catalyst |
+| [Spring AI](agents/spring-ai/) | Spring's AI framework for Java, made durable with Catalyst |
 | [Google ADK](agents/adk/) | Agent Development Kit with Gemini integration, made durable with Catalyst |
 | [OpenAI Agents](agents/openai-agents/) | Function tools and agent handoffs from OpenAI, made durable with Catalyst |
 | [Pydantic AI](agents/pydantic-ai/) | Type-safe agent framework with structured outputs, made durable with Catalyst |

--- a/agents/spring-ai/.gitignore
+++ b/agents/spring-ai/.gitignore
@@ -1,0 +1,2 @@
+# Maven build output
+target/

--- a/agents/spring-ai/README.md
+++ b/agents/spring-ai/README.md
@@ -1,0 +1,48 @@
+# Spring AI Quickstarts
+
+Build **durable [Spring AI](https://docs.spring.io/spring-ai/reference/) agents** on Diagrid Catalyst
+using the `io.diagrid.dapr:dapr-spring-ai-starter` package.
+
+The key idea: an ordinary Spring AI app — a `ChatClient` plus `@Tool` beans — becomes **durable across
+restarts purely by adding the starter to the classpath**. There is no durability code in your app. With
+the starter present, every `ChatClient.call()` runs as a Dapr Workflow: the model turns and each tool
+call execute as **checkpointed activities**, so a crash resumes from the last completed step instead of
+starting over. On Catalyst the workflow state store is managed for you — no component YAML needed.
+
+## Quickstarts
+
+| Quickstart | What it shows |
+|------------|---------------|
+| [event-planner](event-planner/) | The drop-in basics: a 3-tool Event Planner agent. Tool 2 crashes the process; on restart the workflow **auto-resumes** from the checkpoint — completed steps are replayed, not re-run. Mirrors the [Microsoft Agent Framework](../microsoft-dotnet/) quickstart. |
+| [crash-recovery](crash-recovery/) | The idempotency story: schedules under a **caller-owned instance id**. Kill the app mid-booking, restart, and re-issue the same id — the call **attaches** to the resumed run and returns the same confirmation code instead of booking twice. |
+| [durable-memory](durable-memory/) | Where the durability boundary sits: durable chat with a `MessageChatMemoryAdvisor`. Spring AI runs advisors **synchronously**, so the memory advisor's response phase (saving the answer) runs only **after a successful call** — a crash keeps the workflow but not the answer, until you re-attach. |
+
+Start with **event-planner** for the "add one dependency, get durability" experience, then
+**crash-recovery** to make a side-effecting tool safe to retry, then **durable-memory** to see where
+the durability boundary sits — the workflow, not Spring AI's caller-side advisor chain.
+
+## Prerequisites
+
+1. [Diagrid CLI](https://docs.diagrid.io/catalyst/references/cli-reference/overview) installed
+2. [JDK 21](https://adoptium.net/) or later, and [Maven 3.9+](https://maven.apache.org/download.cgi)
+3. An [OpenAI API key](https://platform.openai.com/api-keys)
+
+Each quickstart has its own README with the full run steps.
+
+## How durability works
+
+- `dapr-spring-ai-starter` auto-configures a `DurableAdvisor` (attached to every `ChatClient` built
+  from the injected `ChatClient.Builder`) and an in-process Dapr Workflow worker.
+- Each `ChatClient.call()` becomes a Dapr Workflow; the model turn and each `@Tool` call run as
+  separate checkpointed activities.
+- `@Tool` **beans** (not per-call `.defaultTools(...)`) are rediscovered on the restarted worker, so a
+  resumed workflow can run the pending tool activity.
+- A durable activity is *at-least-once*: the tool in flight at crash time re-runs on recovery. Make
+  side-effecting tools idempotent (key off a business value) — the **crash-recovery** quickstart shows
+  the caller-owned-instance-id pattern for exactly this.
+- Durability wraps the **workflow** (model + tool activities), **not** Spring AI's caller-side advisor
+  chain. `DurableAdvisor` is terminal; an advisor's response phase (chat memory, logging, post-processing)
+  runs synchronously *after a successful call* — so it is skipped on a crash/timeout. The
+  **durable-memory** quickstart shows this and how re-attaching completes the chain.
+
+The library lives at [diagridio/java-ai](https://github.com/diagridio/java-ai).

--- a/agents/spring-ai/crash-recovery/README.md
+++ b/agents/spring-ai/crash-recovery/README.md
@@ -1,0 +1,125 @@
+# Spring AI Quickstart - Crash Recovery
+
+This quickstart demonstrates how to recover a durable [Spring AI](https://docs.spring.io/spring-ai/reference/)
+agent from a hard crash using the `io.diagrid.dapr:dapr-spring-ai-starter` package. A booking agent
+schedules its work under an **instance id you own**, so if the app is killed mid-call you can re-issue
+the same request and **attach** to the still-running workflow instead of starting a second booking.
+
+Where the sibling [`event-planner`](../event-planner) quickstart uses side-effect-free tools (so a
+replay is harmless), this one confronts **idempotency** head-on: the tool has a real side effect (a
+booking), and a caller-owned instance id is what makes a retry safe.
+
+## What This Quickstart Demonstrates
+
+- **Caller-owned instance id**: schedule a `ChatClient.call()` under an id you choose via `DurableAdvisor.INSTANCE_ID_KEY`
+- **Re-attach on recovery**: re-issuing the same id attaches to the resumed workflow — no duplicate work
+- **Idempotency**: the confirmation code is derived from the booking reference, so a re-attached call returns the *same* code — visible proof the booking was not redone
+- **Crash-safe tools**: a global `@Tool` bean is rediscovered on the restarted worker, so the resumed activity can run it
+
+## Prerequisites
+
+1. [Diagrid CLI](https://docs.diagrid.io/catalyst/references/cli-reference/overview) installed
+2. [JDK 21](https://adoptium.net/) or later, and [Maven 3.9+](https://maven.apache.org/download.cgi)
+3. An [OpenAI API key](https://platform.openai.com/api-keys)
+
+## Setup
+
+```bash
+cd crash-recovery
+
+# Build the project (pre-downloads dependencies)
+mvn package -DskipTests
+```
+
+### Set your API key
+
+**macOS/Linux (bash/zsh):**
+
+```bash
+export OPENAI_API_KEY="your-key-here"
+```
+
+**Windows (PowerShell):**
+
+```powershell
+$env:OPENAI_API_KEY = "your-key-here"
+```
+
+## Running the Quickstart
+
+### 1. Deploy and Run
+
+Log in, create the Catalyst project with agent infrastructure enabled (and set it as the default for this session), register the agent, then run:
+
+```bash
+diagrid login
+diagrid project create spring-ai-crash-recovery --enable-agent-infrastructure --wait --use
+diagrid agent create spring-ai-crash-recovery --wait
+diagrid dev run -f dev-spring-ai-crash-recovery.yaml --approve
+```
+
+### 2. Book under an id you own (blocks ~30s)
+
+From another terminal (**Terminal A**) — this schedules the booking under `trip-42` and blocks while the slow tool "commits":
+
+```bash
+curl "http://localhost:8080/crash/book?id=trip-42&reference=ABC123"
+```
+
+Watch the app log for `>>> commitReservation(ABC123) — committing over ~30s`.
+
+### 3. Crash the app mid-call
+
+From **Terminal B**, during that window:
+
+```bash
+curl -X POST "http://localhost:8080/crash/kill"
+```
+
+The app process dies (Terminal A's `curl` sees a reset). The workflow `trip-42` keeps living in Catalyst.
+
+## Recovery — re-attach by instance id
+
+Restart the app (the project and agent already exist, so just run):
+
+```bash
+diagrid dev run -f dev-spring-ai-crash-recovery.yaml --approve
+```
+
+The durable runtime resumes instance `trip-42`; the pre-crash LLM turn is not re-executed. Now re-issue
+the **same** call with the **same** id from **Terminal A**:
+
+```bash
+curl "http://localhost:8080/crash/book?id=trip-42&reference=ABC123"
+```
+
+It **attaches** to the resumed run (waiting if it is still committing, or returning the recorded answer
+if it finished) and returns the **same confirmation code** — no second booking:
+
+```text
+Booking ABC123 confirmed. Confirmation code: BK-...
+```
+
+## How It Works
+
+- The booking agent is a **named `ChatClient` bean** (`crashRecoveryAgent`), so it runs under its own
+  per-agent workflow name. Each call sets a caller-owned instance id via
+  `DurableAdvisor.INSTANCE_ID_KEY` — that id is the attach handle a retry re-uses.
+- The booking tool (`SlowBookingTools.commitReservation`) is a **global `@Tool` bean** so it is
+  re-registered on a restarted worker and the resumed activity can run it (a request-scoped tool would
+  be gone after a cold restart). It sleeps ~30s to open the crash window.
+- On a re-issue with the same id, the durable runtime attaches to the existing instance instead of
+  scheduling a new one. If the call's wait budget elapses it throws `DurableCallTimeoutException` with
+  the instance id — re-issue the same id to collect the result.
+
+> **The instance id is a bearer handle you own** — guard it like a primary key. A durable activity is
+> *at-least-once*, so make side-effecting tools idempotent by keying off a business value (here, the
+> booking reference). To re-run a spent id, purge it first.
+
+## Clean Up
+
+Stop the running application with `Ctrl+C`, then delete the Catalyst project:
+
+```bash
+diagrid project delete spring-ai-crash-recovery
+```

--- a/agents/spring-ai/crash-recovery/README.md
+++ b/agents/spring-ai/crash-recovery/README.md
@@ -25,7 +25,7 @@ booking), and a caller-owned instance id is what makes a retry safe.
 ## Setup
 
 ```bash
-cd crash-recovery
+cd agents/spring-ai/crash-recovery
 
 # Build the project (pre-downloads dependencies)
 mvn package -DskipTests

--- a/agents/spring-ai/crash-recovery/dev-spring-ai-crash-recovery.yaml
+++ b/agents/spring-ai/crash-recovery/dev-spring-ai-crash-recovery.yaml
@@ -1,0 +1,8 @@
+version: 1
+common:
+  appLogDestination: console
+apps:
+  - appID: spring-ai-crash-recovery
+    appDirPath: ./
+    appPort: 8080
+    command: ["mvn", "spring-boot:run"]

--- a/agents/spring-ai/crash-recovery/pom.xml
+++ b/agents/spring-ai/crash-recovery/pom.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>4.0.5</version>
+    <relativePath/>
+  </parent>
+
+  <groupId>io.diagrid.quickstart.springai</groupId>
+  <artifactId>crash-recovery</artifactId>
+  <version>1.0.0</version>
+  <name>crash-recovery</name>
+  <description>Catalyst Spring AI Quickstart — durable crash recovery with a caller-owned instance id (re-attach, no double booking)</description>
+
+  <properties>
+    <java.version>21</java.version>
+    <spring-ai.version>2.0.0</spring-ai.version>
+    <dapr.version>1.18.0</dapr.version>
+    <dapr-spring-ai.version>0.1.0</dapr-spring-ai.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- Align Netty across Dapr's grpc-netty (4.1) and Spring Boot 4 / reactor-netty (4.2); the
+           mixed state otherwise breaks the reactor HTTP client (MultiThreadIoEventLoopGroup is 4.2+).
+           Declared first so it wins over the versions the other BOMs pull in. -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>4.2.12.Final</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.ai</groupId>
+        <artifactId>spring-ai-bom</artifactId>
+        <version>${spring-ai.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.dapr</groupId>
+        <artifactId>dapr-sdk-bom</artifactId>
+        <version>${dapr.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <!-- REST endpoints. -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+
+    <!-- Spring AI OpenAI model: ChatClient + tool calling (version managed by the BOM). -->
+    <dependency>
+      <groupId>org.springframework.ai</groupId>
+      <artifactId>spring-ai-starter-model-openai</artifactId>
+    </dependency>
+
+    <!-- Durability. This quickstart also uses the library API directly (DurableAdvisor.INSTANCE_ID_KEY,
+         DurableCallTimeoutException) to schedule under a caller-owned instance id. -->
+    <dependency>
+      <groupId>io.diagrid.dapr</groupId>
+      <artifactId>dapr-spring-ai-starter</artifactId>
+      <version>${dapr-spring-ai.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/agents/spring-ai/crash-recovery/src/main/java/io/diagrid/quickstart/springai/crashrecovery/CrashRecoveryAgentConfig.java
+++ b/agents/spring-ai/crash-recovery/src/main/java/io/diagrid/quickstart/springai/crashrecovery/CrashRecoveryAgentConfig.java
@@ -1,0 +1,32 @@
+package io.diagrid.quickstart.springai.crashrecovery;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Defines the booking agent as a <b>named {@link ChatClient} bean</b> so it runs under its own
+ * per-agent workflow name ({@code spring-ai.crashRecoveryAgent.workflow}) instead of the generic
+ * {@code spring-ai.workflow}. The name is assigned at wiring time from the bean name, and it shows up
+ * in the Catalyst dashboard / {@code dapr workflow list}.
+ *
+ * <p>It must be a {@code ChatClient} <em>bean</em> (not a {@code @Component} that holds a client): the
+ * durability auto-config registers a per-agent workflow name on the in-process worker for every
+ * ChatClient bean, and its bean post-processor attaches the matching per-agent durable advisor.
+ *
+ * <p>The booking tool ({@link SlowBookingTools}) is a global {@code @Tool} bean, so it is advertised
+ * to this agent automatically (and survives a worker restart); this bean wires no tools of its own.
+ */
+@Configuration
+public class CrashRecoveryAgentConfig {
+
+  private static final String SYSTEM = """
+      You are a travel booking assistant. Commit the customer's booking using the
+      commitReservation tool and report the confirmation code it returns. Call the tool
+      exactly once; never invent a confirmation code.""";
+
+  @Bean
+  ChatClient crashRecoveryAgent(ChatClient.Builder builder) {
+    return builder.defaultSystem(SYSTEM).build();
+  }
+}

--- a/agents/spring-ai/crash-recovery/src/main/java/io/diagrid/quickstart/springai/crashrecovery/CrashRecoveryApplication.java
+++ b/agents/spring-ai/crash-recovery/src/main/java/io/diagrid/quickstart/springai/crashrecovery/CrashRecoveryApplication.java
@@ -1,0 +1,12 @@
+package io.diagrid.quickstart.springai.crashrecovery;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class CrashRecoveryApplication {
+
+  public static void main(String[] args) {
+    SpringApplication.run(CrashRecoveryApplication.class, args);
+  }
+}

--- a/agents/spring-ai/crash-recovery/src/main/java/io/diagrid/quickstart/springai/crashrecovery/CrashRecoveryController.java
+++ b/agents/spring-ai/crash-recovery/src/main/java/io/diagrid/quickstart/springai/crashrecovery/CrashRecoveryController.java
@@ -1,0 +1,72 @@
+package io.diagrid.quickstart.springai.crashrecovery;
+
+import io.diagrid.dapr.springai.durable.boot.DurableAdvisor;
+import io.diagrid.dapr.springai.durable.client.DurableCallTimeoutException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Crash-recovery demo: prove a durable {@code ChatClient.call()} survives a hard kill of the app
+ * (which also hosts the in-process workflow worker), and that re-issuing the SAME call with the SAME
+ * instance id attaches to the resumed run instead of starting a second booking.
+ *
+ * <p>Uses the named {@code crashRecoveryAgent} ChatClient bean (see {@link CrashRecoveryAgentConfig}),
+ * so the run appears under the per-agent workflow name {@code spring-ai.crashRecoveryAgent.workflow}.
+ * The instance id is set per call via {@link DurableAdvisor#INSTANCE_ID_KEY} — that is the attach
+ * handle a repeat call re-uses.
+ *
+ * <pre>
+ * # 1. Terminal A — book under an id YOU own. Blocks ~30s while the slow tool "commits".
+ * curl "http://localhost:8080/crash/book?id=trip-42&amp;reference=ABC123"
+ * # 2. Terminal B — during that window, SIGKILL the app (worker + blocked caller both die):
+ * curl -X POST "http://localhost:8080/crash/kill"
+ * # 3. Restart the app. The durable runtime resumes instance trip-42.
+ * # 4. Terminal A — re-issue the SAME call. It ATTACHES and returns the same confirmation:
+ * curl "http://localhost:8080/crash/book?id=trip-42&amp;reference=ABC123"
+ * </pre>
+ */
+@RestController
+public class CrashRecoveryController {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CrashRecoveryController.class);
+
+  private final ChatClient agent;
+
+  public CrashRecoveryController(@Qualifier("crashRecoveryAgent") ChatClient agent) {
+    this.agent = agent;
+  }
+
+  /** Book under a caller-chosen id; a repeat with the same id attaches to the existing run. */
+  @GetMapping("/crash/book")
+  public ResponseEntity<String> book(
+      @RequestParam String id, @RequestParam(defaultValue = "ABC123") String reference) {
+    try {
+      String answer = agent.prompt()
+          .user("Confirm the booking with reference " + reference + ".")
+          .advisors(a -> a.param(DurableAdvisor.INSTANCE_ID_KEY, id))
+          .call()
+          .content();
+      return ResponseEntity.ok(answer + "\n");
+    } catch (DurableCallTimeoutException e) {
+      // Wait budget elapsed (not a failure): the run is still going. Re-issue the same call with the
+      // same id to attach and collect the result.
+      return ResponseEntity.accepted()
+          .body("still running as " + e.instanceId()
+              + " — re-issue GET /crash/book?id=" + id + " to attach\n");
+    }
+  }
+
+  /** Simulate a crash: halt the JVM abruptly (skips shutdown hooks), like SIGKILL. Demo only. */
+  @PostMapping("/crash/kill")
+  public void kill() {
+    LOG.warn(">>> /crash/kill — halting the JVM to simulate a worker crash");
+    Runtime.getRuntime().halt(137);
+  }
+}

--- a/agents/spring-ai/crash-recovery/src/main/java/io/diagrid/quickstart/springai/crashrecovery/SlowBookingTools.java
+++ b/agents/spring-ai/crash-recovery/src/main/java/io/diagrid/quickstart/springai/crashrecovery/SlowBookingTools.java
@@ -1,0 +1,53 @@
+package io.diagrid.quickstart.springai.crashrecovery;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * A deliberately slow booking tool that opens a window for the crash-recovery demo.
+ *
+ * <p><b>Why a {@code @Tool} Spring bean</b> (not a per-call {@code .defaultTools(new SlowBookingTools())}):
+ * the durability layer rediscovers {@code @Tool} beans at startup, so after the app is killed mid-tool
+ * the tool is re-registered on the fresh worker and the resumed activity can run it. A request-scoped
+ * tool attached per call is registered in memory at call time and is NOT re-registered after a cold
+ * restart — the resumed activity would fail to resolve it.
+ *
+ * <p>The tool runs as a durable activity: it logs a start marker, sleeps for {@code delaySeconds}, then
+ * logs a commit marker and returns a confirmation code. The sleep is the window in which you SIGKILL
+ * the app (see {@link CrashRecoveryController}). Killing there interrupts this activity mid-flight; on
+ * restart the durable runtime re-runs this (incomplete) activity from the start, while NOT re-running
+ * any activity that already completed before the crash. The confirmation code is derived from the
+ * reference, so a re-attached call returns the <em>same</em> code — visible proof the booking was not
+ * redone.
+ */
+@Component
+public class SlowBookingTools {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SlowBookingTools.class);
+
+  private final int delaySeconds;
+
+  public SlowBookingTools(@Value("${crash-recovery.delay-seconds:30}") int delaySeconds) {
+    this.delaySeconds = delaySeconds;
+  }
+
+  @Tool(name = "commitReservation",
+      description = "Commit a travel reservation with the provider and return a confirmation code")
+  public String commitReservation(@ToolParam(description = "the booking reference") String reference) {
+    LOG.warn(">>> commitReservation({}) — committing over ~{}s. KILL THE APP NOW to test crash"
+        + " recovery (POST /crash/kill, or kill -9). It resumes on restart.", reference, delaySeconds);
+    try {
+      Thread.sleep(delaySeconds * 1000L);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("commitReservation interrupted", e);
+    }
+    String code = "BK-" + Integer.toHexString(reference.hashCode()).toUpperCase();
+    LOG.info(">>> commitReservation({}) — committed. Confirmation code: {}", reference, code);
+    return "Booking " + reference + " confirmed. Confirmation code: " + code;
+  }
+}

--- a/agents/spring-ai/crash-recovery/src/main/resources/application.properties
+++ b/agents/spring-ai/crash-recovery/src/main/resources/application.properties
@@ -1,0 +1,31 @@
+server.port=8080
+# The Dapr app-id (set here and in the dev-run file). Keep it stable across restarts so a resumed
+# workflow belongs to the same app.
+spring.application.name=spring-ai-crash-recovery
+
+# Java 21 virtual threads: the blocking ChatClient.call() (it waits ~30s on the slow tool) parks a
+# virtual thread instead of a platform one.
+spring.threads.virtual.enabled=true
+
+# ── Durability (dapr-spring-ai) ──────────────────────────────────────────────
+# Each ChatClient.call() runs as a Dapr Workflow. On Catalyst the workflow state store is managed for
+# you (no component YAML needed). completion-timeout is the wait budget for the blocking call: kept
+# generous (> the slow tool's ~30s) so the first /crash/book blocks through the crash window. If it
+# elapses the workflow keeps running and the call throws DurableCallTimeoutException with the instance
+# id — re-issue the same id to attach.
+dapr.spring-ai.enabled=true
+dapr.spring-ai.completion-timeout=2m
+
+# How long commitReservation "commits" for — the window in which you kill the app.
+crash-recovery.delay-seconds=30
+
+# ── LLM: OpenAI via Spring AI ────────────────────────────────────────────────
+# Export OPENAI_API_KEY in the environment. Swap the model freely.
+spring.ai.openai.api-key=${OPENAI_API_KEY}
+spring.ai.openai.chat.model=gpt-4o-mini
+
+logging.level.io.diagrid.quickstart.springai=INFO
+# Quiet the Dapr Workflow engine's internal chatter (per-request WIRETRACE, activity dispatch, runtime
+# registration) so the demo shows just the agent's own logs. The durabletask SDK logs these at INFO.
+logging.level.io.dapr.durabletask=WARN
+logging.level.io.dapr.workflows=WARN

--- a/agents/spring-ai/crash-recovery/test.http
+++ b/agents/spring-ai/crash-recovery/test.http
@@ -1,0 +1,6 @@
+### 1. Book under an id you own — blocks ~30s while the slow tool "commits".
+###    Kill the app during this window (request below), then restart and re-send this exact request.
+GET http://localhost:8080/crash/book?id=trip-42&reference=ABC123
+
+### 2. Simulate a crash: SIGKILL the app while the booking above is in flight.
+POST http://localhost:8080/crash/kill

--- a/agents/spring-ai/durable-memory/README.md
+++ b/agents/spring-ai/durable-memory/README.md
@@ -1,0 +1,138 @@
+# Spring AI Quickstart - Durable Memory
+
+This quickstart shows **what durability does and does not cover** when you combine the
+`dapr-spring-ai-starter` with Spring AI's memory. It is a durable chat agent whose conversation is
+persisted with a `MessageChatMemoryAdvisor` backed by the `dapr-spring-ai-memory` Dapr state store.
+
+The key lesson: **Spring AI runs advisors synchronously, and an advisor's response phase runs only
+after a successful call.** The durable Dapr Workflow (the model call and each `@Tool` call) survives a
+crash — but the memory advisor that records the assistant's answer runs *on the caller thread, after
+the call returns*. Crash mid-call and the workflow lives on, yet the answer was never written to
+memory. Only a successful (re-attached) call completes the advisor chain and persists it.
+
+## What This Quickstart Demonstrates
+
+- **Durable memory**: chat memory persisted in a Dapr state store, so conversations survive restarts
+- **The synchronous advisor model**: `MessageChatMemoryAdvisor.before()` saves the user message; `after()` saves the assistant reply — and `after()` only runs on success
+- **The durability boundary**: the workflow (model + tools) is durable; the caller-side advisor response phase is not
+- **Re-attach to complete the chain**: re-issuing the same instance id attaches to the resumed run, succeeds, and *then* the memory advisor records the answer
+
+## Prerequisites
+
+1. [Diagrid CLI](https://docs.diagrid.io/catalyst/references/cli-reference/overview) installed
+2. [JDK 21](https://adoptium.net/) or later, and [Maven 3.9+](https://maven.apache.org/download.cgi)
+3. An [OpenAI API key](https://platform.openai.com/api-keys)
+
+## Setup
+
+```bash
+cd durable-memory
+mvn package -DskipTests
+
+export OPENAI_API_KEY="your-key-here"   # PowerShell: $env:OPENAI_API_KEY = "your-key-here"
+```
+
+## Running the Quickstart
+
+```bash
+diagrid login
+diagrid project create spring-ai-durable-memory --enable-agent-infrastructure --wait --use
+diagrid agent create spring-ai-durable-memory --wait
+diagrid dev run -f dev-spring-ai-durable-memory.yaml --approve
+```
+
+### 1. Start a durable turn (it blocks on a slow tool)
+
+From another terminal — this schedules the booking under an instance id **you own** (`trip-1`) and a
+`conversationId` (`alice`). It blocks ~30s while the `commitReservation` tool "commits":
+
+```bash
+curl -X POST "http://localhost:8080/chat?id=trip-1&conversationId=alice&message=Book%20a%20flight%20to%20Oslo,%20reference%20OSLO-1"
+```
+
+### 2. Look at what memory has so far
+
+In a third terminal, while the call above is still blocked:
+
+```bash
+curl "http://localhost:8080/history?conversationId=alice"
+```
+
+You see only the **user** question — the memory advisor's `before` phase saved it, but the `after`
+phase (which saves the answer) has not run yet:
+
+```json
+["USER: Book a flight to Oslo, reference OSLO-1"]
+```
+
+### 3. Crash the app mid-call
+
+```bash
+curl -X POST "http://localhost:8080/crash/kill"
+```
+
+The process dies. The workflow is safe in Catalyst — but the memory advisor's `after` phase never
+ran, so the answer was never recorded.
+
+## Recovery — the response advisor only runs on success
+
+Restart the app (no code changes needed; the project and agent already exist):
+
+```bash
+diagrid dev run -f dev-spring-ai-durable-memory.yaml --approve
+```
+
+Check memory again — still just the question; the crashed call never persisted an answer:
+
+```bash
+curl "http://localhost:8080/history?conversationId=alice"
+# ["USER: Book a flight to Oslo, reference OSLO-1"]
+```
+
+Now **re-issue the same call with the same instance id**. It attaches to the resumed workflow, the
+call returns successfully, and *only now* does the memory advisor's `after` phase record the answer:
+
+```bash
+curl -X POST "http://localhost:8080/chat?id=trip-1&conversationId=alice&message=Book%20a%20flight%20to%20Oslo,%20reference%20OSLO-1"
+
+curl "http://localhost:8080/history?conversationId=alice"
+```
+
+```json
+[
+  "USER: Book a flight to Oslo, reference OSLO-1",
+  "USER: Book a flight to Oslo, reference OSLO-1",
+  "ASSISTANT: Booking OSLO-1 confirmed. Confirmation code: BK-..."
+]
+```
+
+The **assistant answer appears only after the successful call** — that is "response advisors run after
+a success call." Note the user question appears **twice**: the memory advisor's `before` phase runs on
+*every* attempt (the crashed one and the re-attach), so it records the question each time. The answer,
+written in the `after` phase, is recorded once — on success.
+
+## How It Works
+
+- `DurableAdvisor` (from `dapr-spring-ai-starter`) is a **terminal** advisor: it runs the model + tool
+  loop as a Dapr Workflow and returns, short-circuiting the chain. That workflow is what's durable.
+- `MessageChatMemoryAdvisor` sits **before** it in the chain. Its `before` phase (retrieve history, add
+  the user message) runs on the caller thread going in; its `after` phase (add the assistant reply)
+  runs on the caller thread coming back — **only if the durable call returned successfully**.
+- On a crash or a `DurableCallTimeoutException`, the `after` phase never runs. The workflow is durable;
+  the caller-side advisor response phase is not. Re-attaching with the same instance id
+  (`DurableAdvisor.INSTANCE_ID_KEY`) is what lets the full chain complete.
+- Chat memory is backed by the Catalyst-managed `agent-memory` store via `dapr-spring-ai-memory`
+  (`dapr.spring-ai.memory.statestore=agent-memory`).
+
+> **Design takeaway.** Put anything that must survive a crash *inside* the workflow — as a `@Tool`
+> activity, whose result is checkpointed. Advisor response-phase side effects (memory, logging,
+> post-processing) are best-effort on top of a successful call; make retries safe with a caller-owned
+> instance id (see the [crash-recovery](../crash-recovery) quickstart).
+
+## Clean Up
+
+Stop the app with `Ctrl+C`, then delete the Catalyst project:
+
+```bash
+diagrid project delete spring-ai-durable-memory
+```

--- a/agents/spring-ai/durable-memory/dev-spring-ai-durable-memory.yaml
+++ b/agents/spring-ai/durable-memory/dev-spring-ai-durable-memory.yaml
@@ -1,0 +1,8 @@
+version: 1
+common:
+  appLogDestination: console
+apps:
+  - appID: spring-ai-durable-memory
+    appDirPath: ./
+    appPort: 8080
+    command: ["mvn", "spring-boot:run"]

--- a/agents/spring-ai/durable-memory/pom.xml
+++ b/agents/spring-ai/durable-memory/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>4.0.5</version>
+    <relativePath/>
+  </parent>
+
+  <groupId>io.diagrid.quickstart.springai</groupId>
+  <artifactId>durable-memory</artifactId>
+  <version>1.0.0</version>
+  <name>durable-memory</name>
+  <description>Catalyst Spring AI Quickstart — durable chat with memory, showing that response advisors run only after a successful call</description>
+
+  <properties>
+    <java.version>21</java.version>
+    <spring-ai.version>2.0.0</spring-ai.version>
+    <dapr.version>1.18.0</dapr.version>
+    <dapr-spring-ai.version>0.1.0</dapr-spring-ai.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- Align Netty across Dapr's grpc-netty (4.1) and Spring Boot 4 / reactor-netty (4.2); the
+           mixed state otherwise breaks the reactor HTTP client (MultiThreadIoEventLoopGroup is 4.2+).
+           Declared first so it wins over the versions the other BOMs pull in. -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>4.2.12.Final</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.ai</groupId>
+        <artifactId>spring-ai-bom</artifactId>
+        <version>${spring-ai.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.dapr</groupId>
+        <artifactId>dapr-sdk-bom</artifactId>
+        <version>${dapr.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <!-- REST endpoints. -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+
+    <!-- Spring AI OpenAI model: ChatClient + tool calling (version managed by the BOM). -->
+    <dependency>
+      <groupId>org.springframework.ai</groupId>
+      <artifactId>spring-ai-starter-model-openai</artifactId>
+    </dependency>
+
+    <!-- Durability: each ChatClient.call() runs as a Dapr Workflow. -->
+    <dependency>
+      <groupId>io.diagrid.dapr</groupId>
+      <artifactId>dapr-spring-ai-starter</artifactId>
+      <version>${dapr-spring-ai.version}</version>
+    </dependency>
+
+    <!-- Chat memory backed by a Dapr state store (the Catalyst-managed 'agent-memory' store). Backs
+         Spring AI's ChatMemory so MessageChatMemoryAdvisor persists conversations durably. -->
+    <dependency>
+      <groupId>io.diagrid.dapr</groupId>
+      <artifactId>dapr-spring-ai-memory</artifactId>
+      <version>${dapr-spring-ai.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/agents/spring-ai/durable-memory/src/main/java/io/diagrid/quickstart/springai/durablememory/DurableMemoryApplication.java
+++ b/agents/spring-ai/durable-memory/src/main/java/io/diagrid/quickstart/springai/durablememory/DurableMemoryApplication.java
@@ -1,0 +1,12 @@
+package io.diagrid.quickstart.springai.durablememory;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class DurableMemoryApplication {
+
+  public static void main(String[] args) {
+    SpringApplication.run(DurableMemoryApplication.class, args);
+  }
+}

--- a/agents/spring-ai/durable-memory/src/main/java/io/diagrid/quickstart/springai/durablememory/MemoryChatController.java
+++ b/agents/spring-ai/durable-memory/src/main/java/io/diagrid/quickstart/springai/durablememory/MemoryChatController.java
@@ -1,0 +1,101 @@
+package io.diagrid.quickstart.springai.durablememory;
+
+import io.diagrid.dapr.springai.durable.boot.DurableAdvisor;
+import io.diagrid.dapr.springai.durable.client.DurableCallTimeoutException;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
+import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Durable chat with memory — the point of this quickstart is <b>what durability does and does not
+ * cover</b> when Spring AI runs advisors synchronously.
+ *
+ * <p>The {@link MessageChatMemoryAdvisor} is a response advisor: it runs its {@code before} phase on
+ * the caller thread (retrieve history, add the <b>user</b> message to memory), then the durable call
+ * runs as a Dapr Workflow, then it runs its {@code after} phase on the caller thread (add the
+ * <b>assistant</b> reply to memory). The {@code after} phase — like every advisor's response phase —
+ * only runs if the durable call <b>returns successfully</b>.
+ *
+ * <p>So the durable workflow (model + tools) survives a crash, but the assistant reply is persisted to
+ * memory only on a successful call. Crash mid-call and the conversation keeps the question (saved in
+ * {@code before}) but not the answer; re-issue the same instance id, the call attaches and succeeds,
+ * and only then does the memory advisor record the answer.
+ */
+@RestController
+public class MemoryChatController {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MemoryChatController.class);
+
+  private static final String SYSTEM = """
+      You are a booking assistant that remembers the conversation. When the user asks to book,
+      call the commitReservation tool exactly once and report the confirmation code it returns.
+      Refer back to details the user shared earlier in this conversation.""";
+
+  private final ChatClient chat;
+  private final ChatMemory chatMemory;
+
+  public MemoryChatController(ChatClient.Builder builder, ChatMemory chatMemory) {
+    this.chatMemory = chatMemory;
+    this.chat =
+        builder
+            .defaultSystem(SYSTEM)
+            .defaultAdvisors(MessageChatMemoryAdvisor.builder(chatMemory).build())
+            .build();
+  }
+
+  /**
+   * One durable turn under a caller-owned instance {@code id} (so a repeat attaches on recovery) and a
+   * {@code conversationId} (chat-memory grouping). Blocks on the slow booking tool — the crash window.
+   */
+  @PostMapping("/chat")
+  public ResponseEntity<String> chat(
+      @RequestParam String id,
+      @RequestParam String conversationId,
+      @RequestParam String message) {
+    try {
+      String answer =
+          chat.prompt()
+              .user(message)
+              .advisors(
+                  a ->
+                      a.param(DurableAdvisor.INSTANCE_ID_KEY, id)
+                          .param(ChatMemory.CONVERSATION_ID, conversationId))
+              .call()
+              .content();
+      return ResponseEntity.ok(answer + "\n");
+    } catch (DurableCallTimeoutException e) {
+      // Wait budget elapsed (not a failure): the workflow is still running, so the memory advisor's
+      // response phase has NOT run yet. Re-issue the same id to attach, succeed, and persist the reply.
+      return ResponseEntity.accepted()
+          .body("still running as " + e.instanceId()
+              + " — re-issue POST /chat with the same id to attach and persist the answer\n");
+    }
+  }
+
+  /**
+   * Dump what the memory advisor has persisted for a conversation — the observable proof. After a
+   * crash you see the USER question (saved in {@code before}) but no ASSISTANT answer; after a
+   * successful re-attach the ASSISTANT answer appears.
+   */
+  @GetMapping("/history")
+  public List<String> history(@RequestParam String conversationId) {
+    return chatMemory.get(conversationId).stream()
+        .map(m -> m.getMessageType() + ": " + m.getText())
+        .toList();
+  }
+
+  /** Simulate a crash: halt the JVM abruptly (skips shutdown hooks), like SIGKILL. Demo only. */
+  @PostMapping("/crash/kill")
+  public void kill() {
+    LOG.warn(">>> /crash/kill — halting the JVM to simulate a worker crash");
+    Runtime.getRuntime().halt(137);
+  }
+}

--- a/agents/spring-ai/durable-memory/src/main/java/io/diagrid/quickstart/springai/durablememory/SlowBookingTools.java
+++ b/agents/spring-ai/durable-memory/src/main/java/io/diagrid/quickstart/springai/durablememory/SlowBookingTools.java
@@ -1,0 +1,45 @@
+package io.diagrid.quickstart.springai.durablememory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * A deliberately slow booking tool that opens a window to crash the app mid-call — long enough that
+ * the durable call is still in flight and the memory advisor's response phase has not yet run.
+ *
+ * <p>It is a {@code @Tool} Spring bean so it is rediscovered on a restarted worker and the resumed
+ * activity can run it (a per-call tool would be gone after a cold restart). It runs as a durable
+ * activity: logs a start marker, sleeps for {@code delaySeconds}, then returns a confirmation code
+ * derived from the reference (so a re-attached call returns the same code).
+ */
+@Component
+public class SlowBookingTools {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SlowBookingTools.class);
+
+  private final int delaySeconds;
+
+  public SlowBookingTools(@Value("${crash-recovery.delay-seconds:30}") int delaySeconds) {
+    this.delaySeconds = delaySeconds;
+  }
+
+  @Tool(name = "commitReservation",
+      description = "Commit a travel reservation with the provider and return a confirmation code")
+  public String commitReservation(@ToolParam(description = "the booking reference") String reference) {
+    LOG.warn(">>> commitReservation({}) — committing over ~{}s. KILL THE APP NOW to test crash"
+        + " recovery (POST /crash/kill, or kill -9). It resumes on restart.", reference, delaySeconds);
+    try {
+      Thread.sleep(delaySeconds * 1000L);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("commitReservation interrupted", e);
+    }
+    String code = "BK-" + Integer.toHexString(reference.hashCode()).toUpperCase();
+    LOG.info(">>> commitReservation({}) — committed. Confirmation code: {}", reference, code);
+    return "Booking " + reference + " confirmed. Confirmation code: " + code;
+  }
+}

--- a/agents/spring-ai/durable-memory/src/main/resources/application.properties
+++ b/agents/spring-ai/durable-memory/src/main/resources/application.properties
@@ -1,0 +1,35 @@
+server.port=8080
+# The Dapr app-id (set here and in the dev-run file). Keep it stable across restarts so a resumed
+# workflow belongs to the same app.
+spring.application.name=spring-ai-durable-memory
+
+# Java 21 virtual threads: the blocking ChatClient.call() (it waits on the slow tool) parks a virtual
+# thread instead of a platform one.
+spring.threads.virtual.enabled=true
+
+# ── Durability (dapr-spring-ai) ──────────────────────────────────────────────
+# Each ChatClient.call() runs as a Dapr Workflow. completion-timeout is the wait budget for the
+# blocking call — kept generous (> the slow tool's ~30s) so the first /chat blocks through the crash
+# window; if it elapses the call throws DurableCallTimeoutException and you re-issue the same id.
+dapr.spring-ai.enabled=true
+dapr.spring-ai.completion-timeout=2m
+
+# How long commitReservation "commits" for — the window in which you kill the app.
+crash-recovery.delay-seconds=30
+
+# ── Chat memory (dapr-spring-ai-memory) ──────────────────────────────────────
+# Back Spring AI's ChatMemory with a Dapr state store so conversations persist. 'agent-memory' is the
+# memory store Catalyst provides out of the box.
+dapr.spring-ai.memory.enabled=true
+dapr.spring-ai.memory.statestore=agent-memory
+
+# ── LLM: OpenAI via Spring AI ────────────────────────────────────────────────
+# Export OPENAI_API_KEY in the environment. Swap the model freely.
+spring.ai.openai.api-key=${OPENAI_API_KEY}
+spring.ai.openai.chat.model=gpt-4o-mini
+
+logging.level.io.diagrid.quickstart.springai=INFO
+# Quiet the Dapr Workflow engine's internal chatter (per-request WIRETRACE, activity dispatch, runtime
+# registration) so the demo shows just the agent's own logs. The durabletask SDK logs these at INFO.
+logging.level.io.dapr.durabletask=WARN
+logging.level.io.dapr.workflows=WARN

--- a/agents/spring-ai/durable-memory/test.http
+++ b/agents/spring-ai/durable-memory/test.http
@@ -1,0 +1,10 @@
+### 1. Start a durable turn under an id you own (blocks ~30s on the slow tool).
+###    Kill the app during this window (request #3), then restart and re-send this exact request.
+POST http://localhost:8080/chat?id=trip-1&conversationId=alice&message=Book a flight to Oslo, reference OSLO-1
+
+### 2. Inspect what the memory advisor has persisted for this conversation.
+###    Before the call succeeds you see the USER question but no ASSISTANT answer.
+GET http://localhost:8080/history?conversationId=alice
+
+### 3. Simulate a crash while the booking above is in flight.
+POST http://localhost:8080/crash/kill

--- a/agents/spring-ai/event-planner/README.md
+++ b/agents/spring-ai/event-planner/README.md
@@ -1,0 +1,145 @@
+# Spring AI Quickstart - Event Planner
+
+This quickstart demonstrates how to run a [Spring AI](https://docs.spring.io/spring-ai/reference/)
+agent as a durable Dapr Workflow using the `io.diagrid.dapr:dapr-spring-ai-starter` package. The agent
+acts as an **Event Planner** with three tools that it calls in sequence — tool 2 deliberately crashes
+the process to demonstrate automatic recovery.
+
+The app itself is **plain Spring AI** — a `ChatClient` + three `@Tool` beans + a REST endpoint. There
+is no durability code anywhere in it: adding the starter to the classpath is what turns every
+`ChatClient.call()` into a checkpointed Dapr Workflow.
+
+## What This Quickstart Demonstrates
+
+- **Spring AI + Dapr Workflows**: run a Spring AI agent with durable execution — by adding one dependency, no code changes
+- **OpenAI via Spring AI**: calls OpenAI directly through the `spring-ai-starter-model-openai` `ChatClient`
+- **Crash Recovery**: tool 2 crashes the process; on restart, Catalyst resumes the workflow automatically — completed steps are not re-run
+- **REST API**: trigger the agent via an HTTP endpoint
+
+## Prerequisites
+
+1. [Diagrid CLI](https://docs.diagrid.io/catalyst/references/cli-reference/overview) installed
+2. [JDK 21](https://adoptium.net/) or later, and [Maven 3.9+](https://maven.apache.org/download.cgi)
+3. An [OpenAI API key](https://platform.openai.com/api-keys)
+
+## Setup
+
+```bash
+cd event-planner
+
+# Build the project (pre-downloads dependencies)
+mvn package -DskipTests
+```
+
+### Set your API key
+
+**macOS/Linux (bash/zsh):**
+
+```bash
+export OPENAI_API_KEY="your-key-here"
+```
+
+**Windows (PowerShell):**
+
+```powershell
+$env:OPENAI_API_KEY = "your-key-here"
+```
+
+## Running the Quickstart
+
+### 1. Deploy and Run
+
+Log in, create the Catalyst project with agent infrastructure enabled (and set it as the default for this session), register the agent, then run:
+
+```bash
+diagrid login
+diagrid project create spring-ai-quickstart --enable-agent-infrastructure --wait --use
+diagrid agent create spring-ai-event-planner --wait
+diagrid dev run -f dev-spring-ai-event-planner.yaml --approve
+```
+
+### 2. Trigger the Agent
+
+From another terminal:
+
+Choose one of the following to trigger the endpoint:
+
+**macOS/Linux (curl):**
+
+```bash
+curl -X POST http://localhost:8080/run \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "Find a venue in Austin for a company gala"}'
+```
+
+**Windows (PowerShell):**
+
+```powershell
+Invoke-RestMethod -Method Post -Uri 'http://localhost:8080/run' -ContentType 'application/json' -Body '{"prompt": "Find a venue in Austin for a company gala"}'
+```
+
+**VS Code REST Client (any OS):** Open [`test.http`](./test.http) and click *Send Request* above the request. Requires the [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension.
+
+The agent will:
+1. Call `step_one_search` — finds venues (completes)
+2. Call `step_two_compare` — crashes before completing (process exits)
+
+You'll see:
+
+```text
+== APP == >>> TOOL 1: Searching venues in 'Austin'...
+== APP == >>> TOOL 1 COMPLETE: Found 3 venues
+== APP == >>> TOOL 2: Comparing venues...
+```
+
+The process exits — this is expected. (The `curl` call does not return a result: the app died
+mid-request. The workflow itself is safe in Catalyst and will resume in the next step.)
+
+## Crash Recovery
+
+Open `EventPlannerTools.java` and comment out the crash line in `step_two_compare`:
+
+```java
+// Runtime.getRuntime().halt(1); // 💥 Comment out this line before the second run
+```
+
+Restart (the project and agent already exist, so just run):
+
+```bash
+diagrid dev run -f dev-spring-ai-event-planner.yaml --approve
+```
+
+You do **not** need to trigger the endpoint again — the existing workflow resumes automatically.
+`step_one_search` and the first model turn are **replayed from the workflow history** (not re-executed),
+and execution continues from `step_two_compare`:
+
+```text
+== APP == >>> TOOL 2: Comparing venues...
+== APP == >>> TOOL 2 COMPLETE: Grand Ballroom is the best option
+== APP == >>> TOOL 3: Confirming booking...
+== APP == >>> TOOL 3 COMPLETE: Booking confirmed for Grand Ballroom
+```
+
+## How It Works
+
+- `dapr-spring-ai-starter` auto-configures a `DurableAdvisor` (attached to every `ChatClient` built
+  from the injected `ChatClient.Builder`) and an in-process Dapr Workflow worker.
+- Each `ChatClient.call()` runs as a Dapr Workflow; the model turn and each `@Tool` call run as
+  separate **checkpointed activities**. A crash resumes from the last completed step — completed
+  activities are replayed from history rather than re-executed.
+- The three tools are global `@Tool` beans, so they are rediscovered on the restarted worker and the
+  resumed workflow can run the pending activity.
+
+> **A note on idempotency.** A durable activity is *at-least-once*: the tool that was in flight at
+> crash time re-runs on recovery. This quickstart's tools are side-effect-free, so re-running is
+> harmless. A tool with a real side effect (a booking, a payment) must be made idempotent by the app —
+> see the sibling [`crash-recovery`](../crash-recovery) quickstart, which schedules under a
+> caller-owned instance id so a retry *attaches* to the existing run instead of doing the work twice.
+
+## Clean Up
+
+Stop the running application with `Ctrl+C`, then delete the Catalyst project:
+
+```bash
+diagrid project delete spring-ai-quickstart
+```

--- a/agents/spring-ai/event-planner/dev-spring-ai-event-planner.yaml
+++ b/agents/spring-ai/event-planner/dev-spring-ai-event-planner.yaml
@@ -1,0 +1,8 @@
+version: 1
+common:
+  appLogDestination: console
+apps:
+  - appID: spring-ai-event-planner
+    appDirPath: ./
+    appPort: 8080
+    command: ["mvn", "spring-boot:run"]

--- a/agents/spring-ai/event-planner/pom.xml
+++ b/agents/spring-ai/event-planner/pom.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>4.0.5</version>
+    <relativePath/>
+  </parent>
+
+  <groupId>io.diagrid.quickstart.springai</groupId>
+  <artifactId>event-planner</artifactId>
+  <version>1.0.0</version>
+  <name>event-planner</name>
+  <description>Catalyst Spring AI Quickstart — a durable Event Planner agent with crash recovery</description>
+
+  <properties>
+    <java.version>21</java.version>
+    <spring-ai.version>2.0.0</spring-ai.version>
+    <dapr.version>1.18.0</dapr.version>
+    <dapr-spring-ai.version>0.1.0</dapr-spring-ai.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- Align Netty across Dapr's grpc-netty (4.1) and Spring Boot 4 / reactor-netty (4.2); the
+           mixed state otherwise breaks the reactor HTTP client (MultiThreadIoEventLoopGroup is 4.2+).
+           Declared first so it wins over the versions the other BOMs pull in. -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>4.2.12.Final</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.ai</groupId>
+        <artifactId>spring-ai-bom</artifactId>
+        <version>${spring-ai.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.dapr</groupId>
+        <artifactId>dapr-sdk-bom</artifactId>
+        <version>${dapr.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <!-- REST endpoint. -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+
+    <!-- Spring AI OpenAI model: ChatClient + tool calling (version managed by the BOM). -->
+    <dependency>
+      <groupId>org.springframework.ai</groupId>
+      <artifactId>spring-ai-starter-model-openai</artifactId>
+    </dependency>
+
+    <!-- THE ONLY THING THAT MAKES IT DURABLE: add the starter, change no application code.
+         Every ChatClient.call() then runs as a Dapr Workflow whose model turns and tool calls are
+         checkpointed activities — so a crash resumes from the last completed step. -->
+    <dependency>
+      <groupId>io.diagrid.dapr</groupId>
+      <artifactId>dapr-spring-ai-starter</artifactId>
+      <version>${dapr-spring-ai.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/agents/spring-ai/event-planner/src/main/java/io/diagrid/quickstart/springai/eventplanner/EventPlannerApplication.java
+++ b/agents/spring-ai/event-planner/src/main/java/io/diagrid/quickstart/springai/eventplanner/EventPlannerApplication.java
@@ -1,0 +1,12 @@
+package io.diagrid.quickstart.springai.eventplanner;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class EventPlannerApplication {
+
+  public static void main(String[] args) {
+    SpringApplication.run(EventPlannerApplication.class, args);
+  }
+}

--- a/agents/spring-ai/event-planner/src/main/java/io/diagrid/quickstart/springai/eventplanner/EventPlannerController.java
+++ b/agents/spring-ai/event-planner/src/main/java/io/diagrid/quickstart/springai/eventplanner/EventPlannerController.java
@@ -1,0 +1,42 @@
+package io.diagrid.quickstart.springai.eventplanner;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Ordinary Spring AI usage — no durability code. The {@link ChatClient} is built from the injected
+ * {@link ChatClient.Builder}, which lets the dapr-spring-ai {@code DurableAdvisor} attach automatically.
+ * Every {@code chatClient...call()} then runs as a Dapr Workflow: the model turns and each tool call
+ * are checkpointed activities, so a crash resumes from the last completed step.
+ *
+ * <p>The three {@link EventPlannerTools} are global {@code @Tool} beans, so the durability layer offers
+ * them to this agent automatically — no explicit {@code .defaultTools(...)} needed.
+ */
+@RestController
+public class EventPlannerController {
+
+  private static final String SYSTEM = """
+      You are an event planner. Call all three tools in sequence:
+      1. First call step_one_search with the city name
+      2. Then call step_two_compare with the result from step 1
+      3. Finally call step_three_confirm with the result from step 2
+      Do NOT skip any steps.""";
+
+  private final ChatClient chatClient;
+
+  public EventPlannerController(ChatClient.Builder builder) {
+    this.chatClient = builder.defaultSystem(SYSTEM).build();
+  }
+
+  @PostMapping("/run")
+  public RunResponse run(@RequestBody RunRequest request) {
+    String response = chatClient.prompt().user(request.prompt()).call().content();
+    return new RunResponse(response);
+  }
+
+  public record RunRequest(String prompt) {}
+
+  public record RunResponse(String response) {}
+}

--- a/agents/spring-ai/event-planner/src/main/java/io/diagrid/quickstart/springai/eventplanner/EventPlannerTools.java
+++ b/agents/spring-ai/event-planner/src/main/java/io/diagrid/quickstart/springai/eventplanner/EventPlannerTools.java
@@ -1,0 +1,54 @@
+package io.diagrid.quickstart.springai.eventplanner;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.stereotype.Component;
+
+/**
+ * The Event Planner's three tools, which the agent calls in sequence. These are plain Spring AI
+ * {@code @Tool} methods — there is no durability code here. Because the {@code dapr-spring-ai-starter}
+ * is on the classpath, each call runs as a checkpointed Dapr Workflow activity.
+ *
+ * <p><b>Why a {@code @Tool} Spring bean</b> (and not a per-call {@code .defaultTools(new ...)}): the
+ * durability layer rediscovers {@code @Tool} beans at startup and offers them to every durable agent.
+ * After a crash, the fresh worker re-registers them so the resumed workflow can run the pending
+ * activity. A request-scoped tool would be gone after a cold restart.
+ *
+ * <p><b>Why the tools are side-effect-free</b> (just log + return a string): a durable activity is
+ * <em>at-least-once</em>, so the tool that was in flight at crash time re-runs on recovery. Pure tools
+ * make that replay harmless — which is why {@code step_two_compare} can crash and safely re-run. A
+ * tool with a real side effect (a booking, a payment) must be made idempotent by the application;
+ * the sibling <b>crash-recovery</b> quickstart shows how (caller-owned instance id + re-attach).
+ */
+@Component
+public class EventPlannerTools {
+
+  private static final Logger LOG = LoggerFactory.getLogger(EventPlannerTools.class);
+
+  @Tool(name = "step_one_search",
+      description = "Search for event venues in a city. This is the first step.")
+  public String stepOneSearch(@ToolParam(description = "the city to search in") String city) {
+    LOG.info(">>> TOOL 1: Searching venues in '{}'...", city);
+    LOG.info(">>> TOOL 1 COMPLETE: Found 3 venues");
+    return "Found 3 venues in " + city + ". Now call step_two_compare.";
+  }
+
+  @Tool(name = "step_two_compare",
+      description = "Compare the venue options. This is the second step.")
+  public String stepTwoCompare(@ToolParam(description = "the venues found in step one") String data) {
+    LOG.info(">>> TOOL 2: Comparing venues...");
+    Runtime.getRuntime().halt(1); // 💥 Comment out this line before the second run — then re-run without re-triggering /run and watch the workflow resume. Use halt(), not System.exit(): halt skips JVM shutdown hooks, so it's an abrupt crash (what we want to simulate) and avoids deadlocking on Spring Boot's graceful shutdown, which would wait on this very request thread.
+    LOG.info(">>> TOOL 2 COMPLETE: Grand Ballroom is the best option");
+    return "Grand Ballroom is the best option. Now call step_three_confirm.";
+  }
+
+  @Tool(name = "step_three_confirm",
+      description = "Confirm the venue booking. This is the third and final step.")
+  public String stepThreeConfirm(@ToolParam(description = "the selected venue") String selection) {
+    LOG.info(">>> TOOL 3: Confirming booking...");
+    LOG.info(">>> TOOL 3 COMPLETE: Booking confirmed for Grand Ballroom");
+    return "Booking confirmed for Grand Ballroom. All steps complete!";
+  }
+}

--- a/agents/spring-ai/event-planner/src/main/resources/application.properties
+++ b/agents/spring-ai/event-planner/src/main/resources/application.properties
@@ -1,0 +1,27 @@
+server.port=8080
+# The Dapr app-id (set here and in the dev-run file). Keep it stable across restarts so a resumed
+# workflow belongs to the same app.
+spring.application.name=spring-ai-event-planner
+
+# Java 21 virtual threads: a blocking ChatClient.call() (an HTTP call to the model, or a durable
+# workflow) parks a virtual thread instead of a platform one.
+spring.threads.virtual.enabled=true
+
+# ── Durability (dapr-spring-ai) ──────────────────────────────────────────────
+# Each ChatClient.call() runs as a Dapr Workflow. On Catalyst the workflow state store is managed for
+# you (no component YAML needed). These are the defaults, shown for clarity. completion-timeout is the
+# wait budget for the blocking call; if it elapses the workflow keeps running and the call throws
+# DurableCallTimeoutException with the instance id.
+dapr.spring-ai.enabled=true
+dapr.spring-ai.completion-timeout=5m
+
+# ── LLM: OpenAI via Spring AI ────────────────────────────────────────────────
+# Export OPENAI_API_KEY in the environment. Swap the model freely.
+spring.ai.openai.api-key=${OPENAI_API_KEY}
+spring.ai.openai.chat.model=gpt-4o-mini
+
+logging.level.io.diagrid.quickstart.springai=INFO
+# Quiet the Dapr Workflow engine's internal chatter (per-request WIRETRACE, activity dispatch, runtime
+# registration) so the demo shows just the agent's own logs. The durabletask SDK logs these at INFO.
+logging.level.io.dapr.durabletask=WARN
+logging.level.io.dapr.workflows=WARN

--- a/agents/spring-ai/event-planner/test.http
+++ b/agents/spring-ai/event-planner/test.http
@@ -1,0 +1,7 @@
+### Trigger the Event Planner agent
+POST http://localhost:8080/run
+Content-Type: application/json
+
+{
+  "prompt": "Find a venue in Austin for a company gala"
+}


### PR DESCRIPTION
## Summary

Adds three durable **Spring AI** agent quickstarts under `agents/spring-ai/`, built on the `io.diagrid.dapr:dapr-spring-ai-starter` library (Spring Boot 4.0.5 / Java 21 / Spring AI 2.0.0). Each is a standalone Maven app demonstrating one durability lesson:

| Module | Lesson |
|--------|--------|
| `event-planner` | Drop-in durability, mirroring the .NET Event Planner: 3 `@Tool` beans, tool 2 crashes the process, the workflow **auto-resumes** from the checkpoint on restart (completed steps replayed, not re-run). |
| `crash-recovery` | Caller-owned instance id + re-attach — re-issuing the same request attaches to the running workflow instead of double-booking. |
| `durable-memory` | Spring AI's synchronous advisor model — the chat-memory response advisor persists the answer only after a successful call. |

The library adds durability with **no application-code changes** — every `ChatClient.call()` runs as a Dapr Workflow. On Catalyst the workflow store is managed (no `resources/` needed). Also adds a Spring AI row to the top-level README.

## Test plan

- [x] All three modules compile against the released `dapr-spring-ai-starter:0.1.0` (`mvn compile`, Java 21)
- [x] `event-planner` verified end-to-end on Catalyst: crash via `halt(1)`, restart → workflow auto-resumes with no re-curl (completed steps not re-run)
- [x] Smoke-test `crash-recovery` re-attach flow on Catalyst
- [x] Smoke-test `durable-memory` on Catalyst
