### PR TITLE
docs: add per-language READMEs for the workflow, invocation, state, and pubsub quickstarts

### DIFF
--- a/invocation/csharp/README.md
+++ b/invocation/csharp/README.md
@@ -1,0 +1,151 @@
+# Quickstart: Service Invocation (C#)
+
+In this quickstart, you'll run a client and server application on [Catalyst Cloud](https://docs.diagrid.io/operate/hosting/catalyst-cloud). You will learn how to:
+
+- Provision a Catalyst project with apps for two applications using the Diagrid CLI.
+- Invoke a remote service method from a client application using the Dapr Service Invocation API.
+- Verify successful service-to-service communication in the application logs and the Catalyst web console.
+
+```mermaid
+---
+title: Client and Server Apps connected via Catalyst Service Invocation
+---
+flowchart LR
+  APP1(Client App)
+  subgraph Catalyst
+    APPID1(ID: client)
+    APPID2(ID: server)
+  end
+  APP2(Server App)
+  APP1-->APPID1
+  APPID1-->APPID2
+  APPID2-->APP2
+```
+
+## 1. Prerequisites
+
+Before you proceed, ensure you have the following prerequisites installed.
+
+- [Diagrid Catalyst account](https://catalyst.diagrid.io/)
+- [Diagrid CLI](https://docs.diagrid.io/getting-started/install-cli)
+- [Git](https://git-scm.com/downloads)
+- [.NET 10.0](https://dotnet.microsoft.com/en-us/download)
+
+## 2. Log in to Catalyst
+
+Authenticate to Diagrid Catalyst using the following command:
+
+```bash
+diagrid login
+```
+
+This command opens a new browser window where you'll be shown a confirmation code that should match the code in your terminal. Confirm the code, and if you're not logged into Catalyst, you'll be redirected to login.
+
+Confirm your user details are correct using the following command:
+
+```bash
+diagrid whoami
+```
+
+The expected output contains the name of the organization, your user name, and the Catalyst API endpoint.
+
+## 3. Clone Quickstart Code
+
+Clone the quickstart code from GitHub:
+
+```bash
+git clone https://github.com/diagridio/catalyst-quickstarts
+```
+
+Navigate to the quickstart directory:
+
+**macOS/Linux:**
+
+```bash
+cd catalyst-quickstarts/invocation/csharp
+```
+
+**Windows:**
+
+```powershell
+cd catalyst-quickstarts\invocation\csharp
+```
+
+## 4. Install Dependencies
+
+Install the dependencies for both the client and server applications.
+
+```bash
+dotnet restore ./client && dotnet restore ./server
+```
+
+## 5. Run the application with Catalyst Cloud
+
+The `diagrid dev run` command creates your Catalyst project, provisions resources (apps), configures environment variables, and launches your application connected to Catalyst Cloud.
+
+```bash
+diagrid dev run -f invocation-quickstart.yaml --project invocation-quickstart --approve
+```
+
+> **Tip:** Wait a few seconds until you see the log `Connected App ID "server" to localhost:5002` in the terminal before proceeding, to ensure both applications are up and running.
+
+## 6. Invoke the service
+
+With the quickstart running, test the Service Invocation API by sending a request from the client app to the server app.
+
+### 6.1 Send a request
+
+Open a new terminal and invoke the server app through the client app:
+
+**macOS/Linux (curl):**
+
+```bash
+curl -i -X POST http://localhost:5001/order -H "Content-Type: application/json" -d '{"orderId":1}'
+```
+
+**Windows (PowerShell):**
+
+```powershell
+Invoke-RestMethod -Method Post -Uri "http://localhost:5001/order" -ContentType "application/json" -Body '{"orderId":1}'
+```
+
+**Any OS (VS Code REST Client):** open [`test.rest`](./test.rest) and click *Send Request* above the request. Requires the [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension.
+
+The expected response is `200 OK` with this body:
+
+```json
+{"message":"Invocation successful","orderId":1,"targetApp":"server"}
+```
+
+In the `diagrid dev run` terminal, the server app logs should indicate the request was successfully received, and the client app logs should show the invocation was successful.
+
+### 6.2 View in the Catalyst web console
+
+Open the [Catalyst Cloud web console](https://catalyst.diagrid.io/call-graph) and navigate to the Topology section, which visualizes the communication between the `client` and `server` applications.
+
+## 7. Clean Up
+
+Press CTRL+C in the terminal that runs `diagrid dev run` to stop the application and disconnect from Catalyst Cloud.
+
+To delete the entire project and all provisioned resources:
+
+```bash
+diagrid project delete invocation-quickstart
+```
+
+## Summary
+
+In this quickstart you:
+
+- Logged in to Catalyst and provisioned a managed service invocation project with a single CLI command (`diagrid dev run`).
+- Invoked a remote server method from a client application using the Dapr Service Invocation API.
+- Verified service-to-service communication through application logs and the Catalyst web console.
+
+Catalyst handled service discovery, routing, and secure communication automatically — no infrastructure to manage.
+
+## Next steps
+
+- Explore the [Dapr API SDK guides](https://docs.diagrid.io/develop/dapr-apis) to integrate service invocation into your own applications.
+- Try the [Pub/Sub quickstart](https://docs.diagrid.io/getting-started/quickstarts/dapr-apis/pubsub) to add event-driven messaging between your services.
+- Read the full [Service Invocation quickstart docs](https://docs.diagrid.io/getting-started/quickstarts/dapr-apis/invocation).
+- Browse all [Catalyst quickstarts](../../README.md) in this repository.

--- a/invocation/java/README.md
+++ b/invocation/java/README.md
@@ -1,0 +1,152 @@
+# Quickstart: Service Invocation (Java)
+
+In this quickstart, you'll run a client and server application on [Catalyst Cloud](https://docs.diagrid.io/operate/hosting/catalyst-cloud). You will learn how to:
+
+- Provision a Catalyst project with apps for two applications using the Diagrid CLI.
+- Invoke a remote service method from a client application using the Dapr Service Invocation API.
+- Verify successful service-to-service communication in the application logs and the Catalyst web console.
+
+```mermaid
+---
+title: Client and Server Apps connected via Catalyst Service Invocation
+---
+flowchart LR
+  APP1(Client App)
+  subgraph Catalyst
+    APPID1(ID: client)
+    APPID2(ID: server)
+  end
+  APP2(Server App)
+  APP1-->APPID1
+  APPID1-->APPID2
+  APPID2-->APP2
+```
+
+## 1. Prerequisites
+
+Before you proceed, ensure you have the following prerequisites installed.
+
+- [Diagrid Catalyst account](https://catalyst.diagrid.io/)
+- [Diagrid CLI](https://docs.diagrid.io/getting-started/install-cli)
+- [Git](https://git-scm.com/downloads)
+- Java 17+: [OracleJDK](https://www.oracle.com/java/technologies/downloads/) or [OpenJDK](https://jdk.java.net/)
+- [Apache Maven 3.9.5+](https://maven.apache.org/download.cgi)
+
+## 2. Log in to Catalyst
+
+Authenticate to Diagrid Catalyst using the following command:
+
+```bash
+diagrid login
+```
+
+This command opens a new browser window where you'll be shown a confirmation code that should match the code in your terminal. Confirm the code, and if you're not logged into Catalyst, you'll be redirected to login.
+
+Confirm your user details are correct using the following command:
+
+```bash
+diagrid whoami
+```
+
+The expected output contains the name of the organization, your user name, and the Catalyst API endpoint.
+
+## 3. Clone Quickstart Code
+
+Clone the quickstart code from GitHub:
+
+```bash
+git clone https://github.com/diagridio/catalyst-quickstarts
+```
+
+Navigate to the quickstart directory:
+
+**macOS/Linux:**
+
+```bash
+cd catalyst-quickstarts/invocation/java
+```
+
+**Windows:**
+
+```powershell
+cd catalyst-quickstarts\invocation\java
+```
+
+## 4. Install Dependencies
+
+Install the dependencies for both the client and server applications.
+
+```bash
+mvn clean install -f ./client && mvn clean install -f ./server
+```
+
+## 5. Run the application with Catalyst Cloud
+
+The `diagrid dev run` command creates your Catalyst project, provisions resources (apps), configures environment variables, and launches your application connected to Catalyst Cloud.
+
+```bash
+diagrid dev run -f invocation-quickstart.yaml --project invocation-quickstart --approve
+```
+
+> **Tip:** Wait a few seconds until you see the log `Connected App ID "server" to localhost:5002` in the terminal before proceeding, to ensure both applications are up and running.
+
+## 6. Invoke the service
+
+With the quickstart running, test the Service Invocation API by sending a request from the client app to the server app.
+
+### 6.1 Send a request
+
+Open a new terminal and invoke the server app through the client app:
+
+**macOS/Linux (curl):**
+
+```bash
+curl -i -X POST http://localhost:5001/order -H "Content-Type: application/json" -d '{"orderId":1}'
+```
+
+**Windows (PowerShell):**
+
+```powershell
+Invoke-RestMethod -Method Post -Uri "http://localhost:5001/order" -ContentType "application/json" -Body '{"orderId":1}'
+```
+
+**Any OS (VS Code REST Client):** open [`test.rest`](./test.rest) and click *Send Request* above the request. Requires the [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension.
+
+The expected response is `200 OK` with this body:
+
+```json
+{"message":"Invocation successful","orderId":1,"targetApp":"server"}
+```
+
+In the `diagrid dev run` terminal, the server app logs should indicate the request was successfully received, and the client app logs should show the invocation was successful.
+
+### 6.2 View in the Catalyst web console
+
+Open the [Catalyst Cloud web console](https://catalyst.diagrid.io/call-graph) and navigate to the Topology section, which visualizes the communication between the `client` and `server` applications.
+
+## 7. Clean Up
+
+Press CTRL+C in the terminal that runs `diagrid dev run` to stop the application and disconnect from Catalyst Cloud.
+
+To delete the entire project and all provisioned resources:
+
+```bash
+diagrid project delete invocation-quickstart
+```
+
+## Summary
+
+In this quickstart you:
+
+- Logged in to Catalyst and provisioned a managed service invocation project with a single CLI command (`diagrid dev run`).
+- Invoked a remote server method from a client application using the Dapr Service Invocation API.
+- Verified service-to-service communication through application logs and the Catalyst web console.
+
+Catalyst handled service discovery, routing, and secure communication automatically — no infrastructure to manage.
+
+## Next steps
+
+- Explore the [Dapr API SDK guides](https://docs.diagrid.io/develop/dapr-apis) to integrate service invocation into your own applications.
+- Try the [Pub/Sub quickstart](https://docs.diagrid.io/getting-started/quickstarts/dapr-apis/pubsub) to add event-driven messaging between your services.
+- Read the full [Service Invocation quickstart docs](https://docs.diagrid.io/getting-started/quickstarts/dapr-apis/invocation).
+- Browse all [Catalyst quickstarts](../../README.md) in this repository.

--- a/invocation/javascript/README.md
+++ b/invocation/javascript/README.md
@@ -1,0 +1,151 @@
+# Quickstart: Service Invocation (JavaScript)
+
+In this quickstart, you'll run a client and server application on [Catalyst Cloud](https://docs.diagrid.io/operate/hosting/catalyst-cloud). You will learn how to:
+
+- Provision a Catalyst project with apps for two applications using the Diagrid CLI.
+- Invoke a remote service method from a client application using the Dapr Service Invocation API.
+- Verify successful service-to-service communication in the application logs and the Catalyst web console.
+
+```mermaid
+---
+title: Client and Server Apps connected via Catalyst Service Invocation
+---
+flowchart LR
+  APP1(Client App)
+  subgraph Catalyst
+    APPID1(ID: client)
+    APPID2(ID: server)
+  end
+  APP2(Server App)
+  APP1-->APPID1
+  APPID1-->APPID2
+  APPID2-->APP2
+```
+
+## 1. Prerequisites
+
+Before you proceed, ensure you have the following prerequisites installed.
+
+- [Diagrid Catalyst account](https://catalyst.diagrid.io/)
+- [Diagrid CLI](https://docs.diagrid.io/getting-started/install-cli)
+- [Git](https://git-scm.com/downloads)
+- [Node.JS LTS](https://nodejs.org/en/)
+
+## 2. Log in to Catalyst
+
+Authenticate to Diagrid Catalyst using the following command:
+
+```bash
+diagrid login
+```
+
+This command opens a new browser window where you'll be shown a confirmation code that should match the code in your terminal. Confirm the code, and if you're not logged into Catalyst, you'll be redirected to login.
+
+Confirm your user details are correct using the following command:
+
+```bash
+diagrid whoami
+```
+
+The expected output contains the name of the organization, your user name, and the Catalyst API endpoint.
+
+## 3. Clone Quickstart Code
+
+Clone the quickstart code from GitHub:
+
+```bash
+git clone https://github.com/diagridio/catalyst-quickstarts
+```
+
+Navigate to the quickstart directory:
+
+**macOS/Linux:**
+
+```bash
+cd catalyst-quickstarts/invocation/javascript
+```
+
+**Windows:**
+
+```powershell
+cd catalyst-quickstarts\invocation\javascript
+```
+
+## 4. Install Dependencies
+
+Install the dependencies for both the client and server applications.
+
+```bash
+npm install --prefix ./client && npm install --prefix ./server
+```
+
+## 5. Run the application with Catalyst Cloud
+
+The `diagrid dev run` command creates your Catalyst project, provisions resources (apps), configures environment variables, and launches your application connected to Catalyst Cloud.
+
+```bash
+diagrid dev run -f invocation-quickstart.yaml --project invocation-quickstart --approve
+```
+
+> **Tip:** Wait a few seconds until you see the log `Connected App ID "server" to localhost:5002` in the terminal before proceeding, to ensure both applications are up and running.
+
+## 6. Invoke the service
+
+With the quickstart running, test the Service Invocation API by sending a request from the client app to the server app.
+
+### 6.1 Send a request
+
+Open a new terminal and invoke the server app through the client app:
+
+**macOS/Linux (curl):**
+
+```bash
+curl -i -X POST http://localhost:5001/order -H "Content-Type: application/json" -d '{"orderId":1}'
+```
+
+**Windows (PowerShell):**
+
+```powershell
+Invoke-RestMethod -Method Post -Uri "http://localhost:5001/order" -ContentType "application/json" -Body '{"orderId":1}'
+```
+
+**Any OS (VS Code REST Client):** open [`test.rest`](./test.rest) and click *Send Request* above the request. Requires the [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension.
+
+The expected response is `200 OK` with this body:
+
+```json
+{"message":"Invocation successful","orderId":1,"targetApp":"server"}
+```
+
+In the `diagrid dev run` terminal, the server app logs should indicate the request was successfully received, and the client app logs should show the invocation was successful.
+
+### 6.2 View in the Catalyst web console
+
+Open the [Catalyst Cloud web console](https://catalyst.diagrid.io/call-graph) and navigate to the Topology section, which visualizes the communication between the `client` and `server` applications.
+
+## 7. Clean Up
+
+Press CTRL+C in the terminal that runs `diagrid dev run` to stop the application and disconnect from Catalyst Cloud.
+
+To delete the entire project and all provisioned resources:
+
+```bash
+diagrid project delete invocation-quickstart
+```
+
+## Summary
+
+In this quickstart you:
+
+- Logged in to Catalyst and provisioned a managed service invocation project with a single CLI command (`diagrid dev run`).
+- Invoked a remote server method from a client application using the Dapr Service Invocation API.
+- Verified service-to-service communication through application logs and the Catalyst web console.
+
+Catalyst handled service discovery, routing, and secure communication automatically — no infrastructure to manage.
+
+## Next steps
+
+- Explore the [Dapr API SDK guides](https://docs.diagrid.io/develop/dapr-apis) to integrate service invocation into your own applications.
+- Try the [Pub/Sub quickstart](https://docs.diagrid.io/getting-started/quickstarts/dapr-apis/pubsub) to add event-driven messaging between your services.
+- Read the full [Service Invocation quickstart docs](https://docs.diagrid.io/getting-started/quickstarts/dapr-apis/invocation).
+- Browse all [Catalyst quickstarts](../../README.md) in this repository.

--- a/invocation/python/README.md
+++ b/invocation/python/README.md
@@ -1,0 +1,170 @@
+# Quickstart: Service Invocation (Python)
+
+In this quickstart, you'll run a client and server application on [Catalyst Cloud](https://docs.diagrid.io/operate/hosting/catalyst-cloud). You will learn how to:
+
+- Provision a Catalyst project with apps for two applications using the Diagrid CLI.
+- Invoke a remote service method from a client application using the Dapr Service Invocation API.
+- Verify successful service-to-service communication in the application logs and the Catalyst web console.
+
+```mermaid
+---
+title: Client and Server Apps connected via Catalyst Service Invocation
+---
+flowchart LR
+  APP1(Client App)
+  subgraph Catalyst
+    APPID1(ID: client)
+    APPID2(ID: server)
+  end
+  APP2(Server App)
+  APP1-->APPID1
+  APPID1-->APPID2
+  APPID2-->APP2
+```
+
+## 1. Prerequisites
+
+Before you proceed, ensure you have the following prerequisites installed.
+
+- [Diagrid Catalyst account](https://catalyst.diagrid.io/)
+- [Diagrid CLI](https://docs.diagrid.io/getting-started/install-cli)
+- [Git](https://git-scm.com/downloads)
+- [Python 3.12+](https://www.python.org/downloads/) & [uv](https://docs.astral.sh/uv/#installation)
+
+## 2. Log in to Catalyst
+
+Authenticate to Diagrid Catalyst using the following command:
+
+```bash
+diagrid login
+```
+
+This command opens a new browser window where you'll be shown a confirmation code that should match the code in your terminal. Confirm the code, and if you're not logged into Catalyst, you'll be redirected to login.
+
+Confirm your user details are correct using the following command:
+
+```bash
+diagrid whoami
+```
+
+The expected output contains the name of the organization, your user name, and the Catalyst API endpoint.
+
+## 3. Clone Quickstart Code
+
+Clone the quickstart code from GitHub:
+
+```bash
+git clone https://github.com/diagridio/catalyst-quickstarts
+```
+
+Navigate to the quickstart directory:
+
+**macOS/Linux:**
+
+```bash
+cd catalyst-quickstarts/invocation/python
+```
+
+**Windows:**
+
+```powershell
+cd catalyst-quickstarts\invocation\python
+```
+
+## 4. Install Dependencies
+
+Install the dependencies for both the client and server applications.
+
+Create and activate a Python virtual environment:
+
+**macOS/Linux:**
+
+```bash
+uv venv
+source .venv/bin/activate
+```
+
+**Windows:**
+
+```powershell
+uv venv
+.venv\Scripts\activate
+# or use .venv\Scripts\Activate.ps1
+```
+
+Install dependencies:
+
+```bash
+uv sync --active --directory client && uv sync --active --directory server
+```
+
+## 5. Run the application with Catalyst Cloud
+
+The `diagrid dev run` command creates your Catalyst project, provisions resources (apps), configures environment variables, and launches your application connected to Catalyst Cloud.
+
+```bash
+diagrid dev run -f invocation-quickstart.yaml --project invocation-quickstart --approve
+```
+
+> **Tip:** Wait a few seconds until you see the log `Connected App ID "server" to localhost:5002` in the terminal before proceeding, to ensure both applications are up and running.
+
+## 6. Invoke the service
+
+With the quickstart running, test the Service Invocation API by sending a request from the client app to the server app.
+
+### 6.1 Send a request
+
+Open a new terminal and invoke the server app through the client app:
+
+**macOS/Linux (curl):**
+
+```bash
+curl -i -X POST http://localhost:5001/order -H "Content-Type: application/json" -d '{"orderId":1}'
+```
+
+**Windows (PowerShell):**
+
+```powershell
+Invoke-RestMethod -Method Post -Uri "http://localhost:5001/order" -ContentType "application/json" -Body '{"orderId":1}'
+```
+
+**Any OS (VS Code REST Client):** open [`test.rest`](./test.rest) and click *Send Request* above the request. Requires the [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension.
+
+The expected response is `200 OK` with this body:
+
+```json
+{"message":"Invocation successful","orderId":1,"targetApp":"server"}
+```
+
+In the `diagrid dev run` terminal, the server app logs should indicate the request was successfully received, and the client app logs should show the invocation was successful.
+
+### 6.2 View in the Catalyst web console
+
+Open the [Catalyst Cloud web console](https://catalyst.diagrid.io/call-graph) and navigate to the Topology section, which visualizes the communication between the `client` and `server` applications.
+
+## 7. Clean Up
+
+Press CTRL+C in the terminal that runs `diagrid dev run` to stop the application and disconnect from Catalyst Cloud.
+
+To delete the entire project and all provisioned resources:
+
+```bash
+diagrid project delete invocation-quickstart
+```
+
+## Summary
+
+In this quickstart you:
+
+- Logged in to Catalyst and provisioned a managed service invocation project with a single CLI command (`diagrid dev run`).
+- Invoked a remote server method from a client application using the Dapr Service Invocation API.
+- Verified service-to-service communication through application logs and the Catalyst web console.
+
+Catalyst handled service discovery, routing, and secure communication automatically — no infrastructure to manage.
+
+## Next steps
+
+- Explore the [Dapr API SDK guides](https://docs.diagrid.io/develop/dapr-apis) to integrate service invocation into your own applications.
+- Try the [Pub/Sub quickstart](https://docs.diagrid.io/getting-started/quickstarts/dapr-apis/pubsub) to add event-driven messaging between your services.
+- Read the full [Service Invocation quickstart docs](https://docs.diagrid.io/getting-started/quickstarts/dapr-apis/invocation).
+- Browse all [Catalyst quickstarts](../../README.md) in this repository.

--- a/pubsub/csharp/README.md
+++ b/pubsub/csharp/README.md
@@ -1,0 +1,153 @@
+# Quickstart: Publish/Subscribe (C#)
+
+In this quickstart, you'll run a publisher and subscriber application on [Catalyst Cloud](https://docs.diagrid.io/operate/hosting/catalyst-cloud). You will learn how to:
+
+- Provision a Catalyst project with a managed message broker using the Diagrid CLI.
+- Publish messages to a topic and receive them in a subscriber application using the Dapr Pub/Sub API.
+- Inspect published messages in the Catalyst web console.
+
+```mermaid
+---
+title: Publisher and Subscriber Apps connected to Catalyst via Pub/Sub
+---
+flowchart LR
+  APP1(Publisher App)
+  subgraph Catalyst
+    APPID1(ID: publisher)
+    BROKER@{ shape: das, label: "Message broker" }
+    APPID2(ID: subscriber)
+  end
+  APP2(Subscriber App)
+  APP1-->APPID1
+  APPID1-.->BROKER
+  BROKER-.->APPID2
+  APPID2-->APP2
+```
+
+## 1. Prerequisites
+
+Before you proceed, ensure you have the following prerequisites installed.
+
+- [Diagrid Catalyst account](https://catalyst.diagrid.io/)
+- [Diagrid CLI](https://docs.diagrid.io/getting-started/install-cli)
+- [Git](https://git-scm.com/downloads)
+- [.NET 10.0](https://dotnet.microsoft.com/en-us/download)
+
+## 2. Log in to Catalyst
+
+Authenticate to Diagrid Catalyst using the following command:
+
+```bash
+diagrid login
+```
+
+This command opens a new browser window where you'll be shown a confirmation code that should match the code in your terminal. Confirm the code, and if you're not logged into Catalyst, you'll be redirected to login.
+
+Confirm your user details are correct using the following command:
+
+```bash
+diagrid whoami
+```
+
+The expected output contains the name of the organization, your user name, and the Catalyst API endpoint.
+
+## 3. Clone Quickstart Code
+
+Clone the quickstart code from GitHub:
+
+```bash
+git clone https://github.com/diagridio/catalyst-quickstarts
+```
+
+Navigate to the quickstart directory:
+
+**macOS/Linux:**
+
+```bash
+cd catalyst-quickstarts/pubsub/csharp
+```
+
+**Windows:**
+
+```powershell
+cd catalyst-quickstarts\pubsub\csharp
+```
+
+## 4. Install Dependencies
+
+Install the dependencies for both the publisher and subscriber applications.
+
+```bash
+dotnet restore ./publisher && dotnet restore ./subscriber
+```
+
+## 5. Run the application with Catalyst Cloud
+
+The `diagrid dev run` command creates your Catalyst project, provisions resources (apps, Diagrid Pub/Sub service and topic), configures environment variables, and launches your application connected to Catalyst Cloud.
+
+```bash
+diagrid dev run -f pubsub-quickstart.yaml --project pubsub-quickstart --approve
+```
+
+> **Tip:** Wait a few seconds until you see the logs `Connected App ID "publisher" to localhost:5001` and `Connected App ID "subscriber" to localhost:5002` in the terminal before proceeding, to ensure both applications are up and running.
+
+## 6. Publish and receive a message
+
+With the quickstart running, test the Pub/Sub API by publishing a message and verifying it was received by the subscriber.
+
+### 6.1 Publish a message
+
+Open a new terminal and publish an order message to the `orders` topic:
+
+**macOS/Linux (curl):**
+
+```bash
+curl -i -X POST http://localhost:5001/order -H "Content-Type: application/json" -d '{"orderId":1}'
+```
+
+**Windows (PowerShell):**
+
+```powershell
+Invoke-RestMethod -Method Post -Uri "http://localhost:5001/order" -ContentType "application/json" -Body '{"orderId":1}'
+```
+
+**Any OS (VS Code REST Client):** open [`test.rest`](./test.rest) and click *Send Request* above the request. Requires the [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension.
+
+The expected response is `201 Created` with this body:
+
+```json
+{"id":1,"message":"Message published successfully","topic":"orders"}
+```
+
+In the `diagrid dev run` terminal, the publisher app logs should indicate a message was successfully published, and the subscriber app logs should show the message was received on its `/neworder` route.
+
+### 6.2 View in the Catalyst web console
+
+Open the [Catalyst Cloud web console](https://catalyst.diagrid.io/pub-sub/pubsub) and navigate to the Pub/Sub topic explorer (Resources > Managed Pub/Sub). When the `Pending Message Count` for the `orders` topic reaches 0, the subscriber app has successfully processed all messages.
+
+## 7. Clean Up
+
+Press CTRL+C in the terminal that runs `diagrid dev run` to stop the application and disconnect from Catalyst Cloud.
+
+To delete the entire project and all provisioned resources:
+
+```bash
+diagrid project delete pubsub-quickstart
+```
+
+## Summary
+
+In this quickstart you:
+
+- Logged in to Catalyst and provisioned a managed Pub/Sub project with a single CLI command (`diagrid dev run`).
+- Published a message to a topic and verified it was received by a subscriber application.
+- Inspected message delivery status using the Catalyst Pub/Sub topic explorer.
+
+Catalyst handled message brokering, topic management, and delivery guarantees automatically — no infrastructure to manage.
+
+## Next steps
+
+- Explore the [Dapr API SDK guides](https://docs.diagrid.io/develop/dapr-apis) to integrate Pub/Sub messaging into your own applications.
+- Try the [State Management quickstart](https://docs.diagrid.io/getting-started/quickstarts/dapr-apis/state) to add persistent storage to your application.
+- Read the full [Publish/Subscribe quickstart docs](https://docs.diagrid.io/getting-started/quickstarts/dapr-apis/pubsub).
+- Browse all [Catalyst quickstarts](../../README.md) in this repository.

--- a/pubsub/java/README.md
+++ b/pubsub/java/README.md
@@ -1,0 +1,154 @@
+# Quickstart: Publish/Subscribe (Java)
+
+In this quickstart, you'll run a publisher and subscriber application on [Catalyst Cloud](https://docs.diagrid.io/operate/hosting/catalyst-cloud). You will learn how to:
+
+- Provision a Catalyst project with a managed message broker using the Diagrid CLI.
+- Publish messages to a topic and receive them in a subscriber application using the Dapr Pub/Sub API.
+- Inspect published messages in the Catalyst web console.
+
+```mermaid
+---
+title: Publisher and Subscriber Apps connected to Catalyst via Pub/Sub
+---
+flowchart LR
+  APP1(Publisher App)
+  subgraph Catalyst
+    APPID1(ID: publisher)
+    BROKER@{ shape: das, label: "Message broker" }
+    APPID2(ID: subscriber)
+  end
+  APP2(Subscriber App)
+  APP1-->APPID1
+  APPID1-.->BROKER
+  BROKER-.->APPID2
+  APPID2-->APP2
+```
+
+## 1. Prerequisites
+
+Before you proceed, ensure you have the following prerequisites installed.
+
+- [Diagrid Catalyst account](https://catalyst.diagrid.io/)
+- [Diagrid CLI](https://docs.diagrid.io/getting-started/install-cli)
+- [Git](https://git-scm.com/downloads)
+- Java 17+: [OracleJDK](https://www.oracle.com/java/technologies/downloads/) or [OpenJDK](https://jdk.java.net/)
+- [Apache Maven 3.9.5+](https://maven.apache.org/download.cgi)
+
+## 2. Log in to Catalyst
+
+Authenticate to Diagrid Catalyst using the following command:
+
+```bash
+diagrid login
+```
+
+This command opens a new browser window where you'll be shown a confirmation code that should match the code in your terminal. Confirm the code, and if you're not logged into Catalyst, you'll be redirected to login.
+
+Confirm your user details are correct using the following command:
+
+```bash
+diagrid whoami
+```
+
+The expected output contains the name of the organization, your user name, and the Catalyst API endpoint.
+
+## 3. Clone Quickstart Code
+
+Clone the quickstart code from GitHub:
+
+```bash
+git clone https://github.com/diagridio/catalyst-quickstarts
+```
+
+Navigate to the quickstart directory:
+
+**macOS/Linux:**
+
+```bash
+cd catalyst-quickstarts/pubsub/java
+```
+
+**Windows:**
+
+```powershell
+cd catalyst-quickstarts\pubsub\java
+```
+
+## 4. Install Dependencies
+
+Install the dependencies for both the publisher and subscriber applications.
+
+```bash
+mvn clean install -f ./publisher && mvn clean install -f ./subscriber
+```
+
+## 5. Run the application with Catalyst Cloud
+
+The `diagrid dev run` command creates your Catalyst project, provisions resources (apps, Diagrid Pub/Sub service and topic), configures environment variables, and launches your application connected to Catalyst Cloud.
+
+```bash
+diagrid dev run -f pubsub-quickstart.yaml --project pubsub-quickstart --approve
+```
+
+> **Tip:** Wait a few seconds until you see the logs `Connected App ID "publisher" to localhost:5001` and `Connected App ID "subscriber" to localhost:5002` in the terminal before proceeding, to ensure both applications are up and running.
+
+## 6. Publish and receive a message
+
+With the quickstart running, test the Pub/Sub API by publishing a message and verifying it was received by the subscriber.
+
+### 6.1 Publish a message
+
+Open a new terminal and publish an order message to the `orders` topic:
+
+**macOS/Linux (curl):**
+
+```bash
+curl -i -X POST http://localhost:5001/order -H "Content-Type: application/json" -d '{"orderId":1}'
+```
+
+**Windows (PowerShell):**
+
+```powershell
+Invoke-RestMethod -Method Post -Uri "http://localhost:5001/order" -ContentType "application/json" -Body '{"orderId":1}'
+```
+
+**Any OS (VS Code REST Client):** open [`test.rest`](./test.rest) and click *Send Request* above the request. Requires the [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension.
+
+The expected response is `201 Created` with this body:
+
+```json
+{"id":"1","message":"Message published successfully","topic":"orders"}
+```
+
+In the `diagrid dev run` terminal, the publisher app logs should indicate a message was successfully published, and the subscriber app logs should show the message was received on its `/neworder` route.
+
+### 6.2 View in the Catalyst web console
+
+Open the [Catalyst Cloud web console](https://catalyst.diagrid.io/pub-sub/pubsub) and navigate to the Pub/Sub topic explorer (Resources > Managed Pub/Sub). When the `Pending Message Count` for the `orders` topic reaches 0, the subscriber app has successfully processed all messages.
+
+## 7. Clean Up
+
+Press CTRL+C in the terminal that runs `diagrid dev run` to stop the application and disconnect from Catalyst Cloud.
+
+To delete the entire project and all provisioned resources:
+
+```bash
+diagrid project delete pubsub-quickstart
+```
+
+## Summary
+
+In this quickstart you:
+
+- Logged in to Catalyst and provisioned a managed Pub/Sub project with a single CLI command (`diagrid dev run`).
+- Published a message to a topic and verified it was received by a subscriber application.
+- Inspected message delivery status using the Catalyst Pub/Sub topic explorer.
+
+Catalyst handled message brokering, topic management, and delivery guarantees automatically — no infrastructure to manage.
+
+## Next steps
+
+- Explore the [Dapr API SDK guides](https://docs.diagrid.io/develop/dapr-apis) to integrate Pub/Sub messaging into your own applications.
+- Try the [State Management quickstart](https://docs.diagrid.io/getting-started/quickstarts/dapr-apis/state) to add persistent storage to your application.
+- Read the full [Publish/Subscribe quickstart docs](https://docs.diagrid.io/getting-started/quickstarts/dapr-apis/pubsub).
+- Browse all [Catalyst quickstarts](../../README.md) in this repository.

--- a/pubsub/javascript/README.md
+++ b/pubsub/javascript/README.md
@@ -1,0 +1,153 @@
+# Quickstart: Publish/Subscribe (JavaScript)
+
+In this quickstart, you'll run a publisher and subscriber application on [Catalyst Cloud](https://docs.diagrid.io/operate/hosting/catalyst-cloud). You will learn how to:
+
+- Provision a Catalyst project with a managed message broker using the Diagrid CLI.
+- Publish messages to a topic and receive them in a subscriber application using the Dapr Pub/Sub API.
+- Inspect published messages in the Catalyst web console.
+
+```mermaid
+---
+title: Publisher and Subscriber Apps connected to Catalyst via Pub/Sub
+---
+flowchart LR
+  APP1(Publisher App)
+  subgraph Catalyst
+    APPID1(ID: publisher)
+    BROKER@{ shape: das, label: "Message broker" }
+    APPID2(ID: subscriber)
+  end
+  APP2(Subscriber App)
+  APP1-->APPID1
+  APPID1-.->BROKER
+  BROKER-.->APPID2
+  APPID2-->APP2
+```
+
+## 1. Prerequisites
+
+Before you proceed, ensure you have the following prerequisites installed.
+
+- [Diagrid Catalyst account](https://catalyst.diagrid.io/)
+- [Diagrid CLI](https://docs.diagrid.io/getting-started/install-cli)
+- [Git](https://git-scm.com/downloads)
+- [Node.JS LTS](https://nodejs.org/en/)
+
+## 2. Log in to Catalyst
+
+Authenticate to Diagrid Catalyst using the following command:
+
+```bash
+diagrid login
+```
+
+This command opens a new browser window where you'll be shown a confirmation code that should match the code in your terminal. Confirm the code, and if you're not logged into Catalyst, you'll be redirected to login.
+
+Confirm your user details are correct using the following command:
+
+```bash
+diagrid whoami
+```
+
+The expected output contains the name of the organization, your user name, and the Catalyst API endpoint.
+
+## 3. Clone Quickstart Code
+
+Clone the quickstart code from GitHub:
+
+```bash
+git clone https://github.com/diagridio/catalyst-quickstarts
+```
+
+Navigate to the quickstart directory:
+
+**macOS/Linux:**
+
+```bash
+cd catalyst-quickstarts/pubsub/javascript
+```
+
+**Windows:**
+
+```powershell
+cd catalyst-quickstarts\pubsub\javascript
+```
+
+## 4. Install Dependencies
+
+Install the dependencies for both the publisher and subscriber applications.
+
+```bash
+npm install --prefix ./publisher && npm install --prefix ./subscriber
+```
+
+## 5. Run the application with Catalyst Cloud
+
+The `diagrid dev run` command creates your Catalyst project, provisions resources (apps, Diagrid Pub/Sub service and topic), configures environment variables, and launches your application connected to Catalyst Cloud.
+
+```bash
+diagrid dev run -f pubsub-quickstart.yaml --project pubsub-quickstart --approve
+```
+
+> **Tip:** Wait a few seconds until you see the logs `Connected App ID "publisher" to localhost:5001` and `Connected App ID "subscriber" to localhost:5002` in the terminal before proceeding, to ensure both applications are up and running.
+
+## 6. Publish and receive a message
+
+With the quickstart running, test the Pub/Sub API by publishing a message and verifying it was received by the subscriber.
+
+### 6.1 Publish a message
+
+Open a new terminal and publish an order message to the `orders` topic:
+
+**macOS/Linux (curl):**
+
+```bash
+curl -i -X POST http://localhost:5001/order -H "Content-Type: application/json" -d '{"orderId":1}'
+```
+
+**Windows (PowerShell):**
+
+```powershell
+Invoke-RestMethod -Method Post -Uri "http://localhost:5001/order" -ContentType "application/json" -Body '{"orderId":1}'
+```
+
+**Any OS (VS Code REST Client):** open [`test.rest`](./test.rest) and click *Send Request* above the request. Requires the [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension.
+
+The expected response is `201 Created` with this body:
+
+```json
+{"id":1,"message":"Message published successfully","topic":"orders"}
+```
+
+In the `diagrid dev run` terminal, the publisher app logs should indicate a message was successfully published, and the subscriber app logs should show the message was received on its `/neworder` route.
+
+### 6.2 View in the Catalyst web console
+
+Open the [Catalyst Cloud web console](https://catalyst.diagrid.io/pub-sub/pubsub) and navigate to the Pub/Sub topic explorer (Resources > Managed Pub/Sub). When the `Pending Message Count` for the `orders` topic reaches 0, the subscriber app has successfully processed all messages.
+
+## 7. Clean Up
+
+Press CTRL+C in the terminal that runs `diagrid dev run` to stop the application and disconnect from Catalyst Cloud.
+
+To delete the entire project and all provisioned resources:
+
+```bash
+diagrid project delete pubsub-quickstart
+```
+
+## Summary
+
+In this quickstart you:
+
+- Logged in to Catalyst and provisioned a managed Pub/Sub project with a single CLI command (`diagrid dev run`).
+- Published a message to a topic and verified it was received by a subscriber application.
+- Inspected message delivery status using the Catalyst Pub/Sub topic explorer.
+
+Catalyst handled message brokering, topic management, and delivery guarantees automatically — no infrastructure to manage.
+
+## Next steps
+
+- Explore the [Dapr API SDK guides](https://docs.diagrid.io/develop/dapr-apis) to integrate Pub/Sub messaging into your own applications.
+- Try the [State Management quickstart](https://docs.diagrid.io/getting-started/quickstarts/dapr-apis/state) to add persistent storage to your application.
+- Read the full [Publish/Subscribe quickstart docs](https://docs.diagrid.io/getting-started/quickstarts/dapr-apis/pubsub).
+- Browse all [Catalyst quickstarts](../../README.md) in this repository.

--- a/pubsub/python/README.md
+++ b/pubsub/python/README.md
@@ -1,0 +1,172 @@
+# Quickstart: Publish/Subscribe (Python)
+
+In this quickstart, you'll run a publisher and subscriber application on [Catalyst Cloud](https://docs.diagrid.io/operate/hosting/catalyst-cloud). You will learn how to:
+
+- Provision a Catalyst project with a managed message broker using the Diagrid CLI.
+- Publish messages to a topic and receive them in a subscriber application using the Dapr Pub/Sub API.
+- Inspect published messages in the Catalyst web console.
+
+```mermaid
+---
+title: Publisher and Subscriber Apps connected to Catalyst via Pub/Sub
+---
+flowchart LR
+  APP1(Publisher App)
+  subgraph Catalyst
+    APPID1(ID: publisher)
+    BROKER@{ shape: das, label: "Message broker" }
+    APPID2(ID: subscriber)
+  end
+  APP2(Subscriber App)
+  APP1-->APPID1
+  APPID1-.->BROKER
+  BROKER-.->APPID2
+  APPID2-->APP2
+```
+
+## 1. Prerequisites
+
+Before you proceed, ensure you have the following prerequisites installed.
+
+- [Diagrid Catalyst account](https://catalyst.diagrid.io/)
+- [Diagrid CLI](https://docs.diagrid.io/getting-started/install-cli)
+- [Git](https://git-scm.com/downloads)
+- [Python 3.12+](https://www.python.org/downloads/) & [uv](https://docs.astral.sh/uv/#installation)
+
+## 2. Log in to Catalyst
+
+Authenticate to Diagrid Catalyst using the following command:
+
+```bash
+diagrid login
+```
+
+This command opens a new browser window where you'll be shown a confirmation code that should match the code in your terminal. Confirm the code, and if you're not logged into Catalyst, you'll be redirected to login.
+
+Confirm your user details are correct using the following command:
+
+```bash
+diagrid whoami
+```
+
+The expected output contains the name of the organization, your user name, and the Catalyst API endpoint.
+
+## 3. Clone Quickstart Code
+
+Clone the quickstart code from GitHub:
+
+```bash
+git clone https://github.com/diagridio/catalyst-quickstarts
+```
+
+Navigate to the quickstart directory:
+
+**macOS/Linux:**
+
+```bash
+cd catalyst-quickstarts/pubsub/python
+```
+
+**Windows:**
+
+```powershell
+cd catalyst-quickstarts\pubsub\python
+```
+
+## 4. Install Dependencies
+
+Install the dependencies for both the publisher and subscriber applications.
+
+Create and activate a Python virtual environment:
+
+**macOS/Linux:**
+
+```bash
+uv venv
+source .venv/bin/activate
+```
+
+**Windows:**
+
+```powershell
+uv venv
+.venv\Scripts\activate
+# or use .venv\Scripts\Activate.ps1
+```
+
+Install dependencies:
+
+```bash
+uv sync --active --directory publisher && uv sync --active --directory subscriber
+```
+
+## 5. Run the application with Catalyst Cloud
+
+The `diagrid dev run` command creates your Catalyst project, provisions resources (apps, Diagrid Pub/Sub service and topic), configures environment variables, and launches your application connected to Catalyst Cloud.
+
+```bash
+diagrid dev run -f pubsub-quickstart.yaml --project pubsub-quickstart --approve
+```
+
+> **Tip:** Wait a few seconds until you see the logs `Connected App ID "publisher" to localhost:5001` and `Connected App ID "subscriber" to localhost:5002` in the terminal before proceeding, to ensure both applications are up and running.
+
+## 6. Publish and receive a message
+
+With the quickstart running, test the Pub/Sub API by publishing a message and verifying it was received by the subscriber.
+
+### 6.1 Publish a message
+
+Open a new terminal and publish an order message to the `orders` topic:
+
+**macOS/Linux (curl):**
+
+```bash
+curl -i -X POST http://localhost:5001/order -H "Content-Type: application/json" -d '{"orderId":1}'
+```
+
+**Windows (PowerShell):**
+
+```powershell
+Invoke-RestMethod -Method Post -Uri "http://localhost:5001/order" -ContentType "application/json" -Body '{"orderId":1}'
+```
+
+**Any OS (VS Code REST Client):** open [`test.rest`](./test.rest) and click *Send Request* above the request. Requires the [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension.
+
+The expected response is `201 Created` with this body:
+
+```json
+{"id":1,"message":"Message published successfully","topic":"orders"}
+```
+
+In the `diagrid dev run` terminal, the publisher app logs should indicate a message was successfully published, and the subscriber app logs should show the message was received on its `/neworder` route.
+
+### 6.2 View in the Catalyst web console
+
+Open the [Catalyst Cloud web console](https://catalyst.diagrid.io/pub-sub/pubsub) and navigate to the Pub/Sub topic explorer (Resources > Managed Pub/Sub). When the `Pending Message Count` for the `orders` topic reaches 0, the subscriber app has successfully processed all messages.
+
+## 7. Clean Up
+
+Press CTRL+C in the terminal that runs `diagrid dev run` to stop the application and disconnect from Catalyst Cloud.
+
+To delete the entire project and all provisioned resources:
+
+```bash
+diagrid project delete pubsub-quickstart
+```
+
+## Summary
+
+In this quickstart you:
+
+- Logged in to Catalyst and provisioned a managed Pub/Sub project with a single CLI command (`diagrid dev run`).
+- Published a message to a topic and verified it was received by a subscriber application.
+- Inspected message delivery status using the Catalyst Pub/Sub topic explorer.
+
+Catalyst handled message brokering, topic management, and delivery guarantees automatically — no infrastructure to manage.
+
+## Next steps
+
+- Explore the [Dapr API SDK guides](https://docs.diagrid.io/develop/dapr-apis) to integrate Pub/Sub messaging into your own applications.
+- Try the [State Management quickstart](https://docs.diagrid.io/getting-started/quickstarts/dapr-apis/state) to add persistent storage to your application.
+- Read the full [Publish/Subscribe quickstart docs](https://docs.diagrid.io/getting-started/quickstarts/dapr-apis/pubsub).
+- Browse all [Catalyst quickstarts](../../README.md) in this repository.

--- a/state/csharp/README.md
+++ b/state/csharp/README.md
@@ -1,0 +1,174 @@
+# Quickstart: State Management (C#)
+
+In this quickstart, you'll run a stateful order application on [Catalyst Cloud](https://docs.diagrid.io/operate/hosting/catalyst-cloud). You will learn how to:
+
+- Provision a Catalyst project with a managed KV store using the Diagrid CLI.
+- Save and retrieve state items using the Dapr State API.
+- Inspect stored data in the Catalyst web console.
+
+```mermaid
+---
+title: Order App connected to Catalyst with KV Store
+---
+flowchart LR
+  APP(Order App)
+  subgraph Catalyst
+    APPID(ID: order-app)
+    STATE[(KV Store)]
+  end
+
+  APP<-->APPID
+  APPID<-->STATE
+```
+
+## 1. Prerequisites
+
+Before you proceed, ensure you have the following prerequisites installed.
+
+- [Diagrid Catalyst account](https://catalyst.diagrid.io/)
+- [Diagrid CLI](https://docs.diagrid.io/getting-started/install-cli)
+- [Git](https://git-scm.com/downloads)
+- [.NET 10.0](https://dotnet.microsoft.com/en-us/download)
+
+## 2. Log in to Catalyst
+
+Authenticate to Diagrid Catalyst using the following command:
+
+```bash
+diagrid login
+```
+
+This command opens a new browser window where you'll be shown a confirmation code that should match the code in your terminal. Confirm the code, and if you're not logged into Catalyst, you'll be redirected to login.
+
+Confirm your user details are correct using the following command:
+
+```bash
+diagrid whoami
+```
+
+The expected output contains the name of the organization, your user name, and the Catalyst API endpoint.
+
+## 3. Clone Quickstart Code
+
+Clone the quickstart code from GitHub:
+
+```bash
+git clone https://github.com/diagridio/catalyst-quickstarts
+```
+
+Navigate to the quickstart directory:
+
+**macOS/Linux:**
+
+```bash
+cd catalyst-quickstarts/state/csharp
+```
+
+**Windows:**
+
+```powershell
+cd catalyst-quickstarts\state\csharp
+```
+
+## 4. Install Dependencies
+
+Install the dependencies for the state management application.
+
+```bash
+dotnet restore
+```
+
+## 5. Run the application with Catalyst Cloud
+
+The `diagrid dev run` command creates your Catalyst project, provisions resources (apps, Diagrid KV Store service), configures environment variables, and launches your application connected to Catalyst Cloud.
+
+```bash
+diagrid dev run -f state-quickstart.yaml --project state-quickstart --approve
+```
+
+> **Tip:** Wait a few seconds until you see application logs in the terminal to ensure the application is up and running and connected to Catalyst.
+
+## 6. Call the State API
+
+With the quickstart running, test the State API by storing and retrieving a state item.
+
+### 6.1 Store state
+
+Open a new terminal and save a state item to the Diagrid KV store:
+
+**macOS/Linux (curl):**
+
+```bash
+curl -i -X POST http://localhost:5001/order -H "Content-Type: application/json" -d '{"orderId":1}'
+```
+
+**Windows (PowerShell):**
+
+```powershell
+Invoke-RestMethod -Method Post -Uri "http://localhost:5001/order" -ContentType "application/json" -Body '{"orderId":1}'
+```
+
+**Any OS (VS Code REST Client):** open [`test.rest`](./test.rest) and click *Send Request* above the request. Requires the [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension.
+
+The expected response is `201 Created` with this body:
+
+```json
+{"id":1,"message":"Order created successfully"}
+```
+
+The application logs in the `diagrid dev run` terminal should show an order was saved.
+
+### 6.2 Retrieve state
+
+Confirm the state item was saved successfully by retrieving it:
+
+**macOS/Linux (curl):**
+
+```bash
+curl -i -X GET http://localhost:5001/order/1
+```
+
+**Windows (PowerShell):**
+
+```powershell
+Invoke-RestMethod -Method Get -Uri "http://localhost:5001/order/1"
+```
+
+**Any OS (VS Code REST Client):** open [`test.rest`](./test.rest) and click *Send Request* above the request. Requires the [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension.
+
+The expected response body is:
+
+```json
+{"data":{"orderId":1}}
+```
+
+### 6.3 View in the Catalyst web console
+
+Open the [KV Store data explorer](https://catalyst.diagrid.io/kv-store/kvstore) in the Catalyst Cloud web console (Resources > Managed KV store) and confirm the key-value pair saved by your application appears.
+
+## 7. Clean Up
+
+Press CTRL+C in the terminal that runs `diagrid dev run` to stop the application and disconnect from Catalyst Cloud.
+
+To delete the entire project and all provisioned resources:
+
+```bash
+diagrid project delete state-quickstart
+```
+
+## Summary
+
+In this quickstart you:
+
+- Logged in to Catalyst and provisioned a managed state store project with a single CLI command (`diagrid dev run`).
+- Saved and retrieved state items using the Dapr State API.
+- Inspected stored data using the Catalyst KV Store data explorer.
+
+Catalyst handled state persistence and key-value storage automatically — no infrastructure to manage.
+
+## Next steps
+
+- Explore the [Dapr API SDK guides](https://docs.diagrid.io/develop/dapr-apis) to integrate state management into your own applications.
+- Try the [Pub/Sub quickstart](https://docs.diagrid.io/getting-started/quickstarts/dapr-apis/pubsub) to add event-driven messaging to your application.
+- Read the full [State Management quickstart docs](https://docs.diagrid.io/getting-started/quickstarts/dapr-apis/state).
+- Browse all [Catalyst quickstarts](../../README.md) in this repository.

--- a/state/csharp/README.md
+++ b/state/csharp/README.md
@@ -134,7 +134,7 @@ curl -i -X GET http://localhost:5001/order/1
 Invoke-RestMethod -Method Get -Uri "http://localhost:5001/order/1"
 ```
 
-**Any OS (VS Code REST Client):** open [`test.rest`](./test.rest) and click *Send Request* above the request. Requires the [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension.
+**Any OS (VS Code REST Client):** open [`test.rest`](./test.rest) and click *Send Request* above the request. Note that `test.rest` uses order ID `4` rather than `1`, so the retrieved value reads `4`. Requires the [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension.
 
 The expected response body is:
 

--- a/state/java/README.md
+++ b/state/java/README.md
@@ -1,0 +1,175 @@
+# Quickstart: State Management (Java)
+
+In this quickstart, you'll run a stateful order application on [Catalyst Cloud](https://docs.diagrid.io/operate/hosting/catalyst-cloud). You will learn how to:
+
+- Provision a Catalyst project with a managed KV store using the Diagrid CLI.
+- Save and retrieve state items using the Dapr State API.
+- Inspect stored data in the Catalyst web console.
+
+```mermaid
+---
+title: Order App connected to Catalyst with KV Store
+---
+flowchart LR
+  APP(Order App)
+  subgraph Catalyst
+    APPID(ID: order-app)
+    STATE[(KV Store)]
+  end
+
+  APP<-->APPID
+  APPID<-->STATE
+```
+
+## 1. Prerequisites
+
+Before you proceed, ensure you have the following prerequisites installed.
+
+- [Diagrid Catalyst account](https://catalyst.diagrid.io/)
+- [Diagrid CLI](https://docs.diagrid.io/getting-started/install-cli)
+- [Git](https://git-scm.com/downloads)
+- Java 17+: [OracleJDK](https://www.oracle.com/java/technologies/downloads/) or [OpenJDK](https://jdk.java.net/)
+- [Apache Maven 3.9.5+](https://maven.apache.org/download.cgi)
+
+## 2. Log in to Catalyst
+
+Authenticate to Diagrid Catalyst using the following command:
+
+```bash
+diagrid login
+```
+
+This command opens a new browser window where you'll be shown a confirmation code that should match the code in your terminal. Confirm the code, and if you're not logged into Catalyst, you'll be redirected to login.
+
+Confirm your user details are correct using the following command:
+
+```bash
+diagrid whoami
+```
+
+The expected output contains the name of the organization, your user name, and the Catalyst API endpoint.
+
+## 3. Clone Quickstart Code
+
+Clone the quickstart code from GitHub:
+
+```bash
+git clone https://github.com/diagridio/catalyst-quickstarts
+```
+
+Navigate to the quickstart directory:
+
+**macOS/Linux:**
+
+```bash
+cd catalyst-quickstarts/state/java
+```
+
+**Windows:**
+
+```powershell
+cd catalyst-quickstarts\state\java
+```
+
+## 4. Install Dependencies
+
+Install the dependencies for the state management application.
+
+```bash
+mvn clean install
+```
+
+## 5. Run the application with Catalyst Cloud
+
+The `diagrid dev run` command creates your Catalyst project, provisions resources (apps, Diagrid KV Store service), configures environment variables, and launches your application connected to Catalyst Cloud.
+
+```bash
+diagrid dev run -f state-quickstart.yaml --project state-quickstart --approve
+```
+
+> **Tip:** Wait a few seconds until you see application logs in the terminal to ensure the application is up and running and connected to Catalyst.
+
+## 6. Call the State API
+
+With the quickstart running, test the State API by storing and retrieving a state item.
+
+### 6.1 Store state
+
+Open a new terminal and save a state item to the Diagrid KV store:
+
+**macOS/Linux (curl):**
+
+```bash
+curl -i -X POST http://localhost:5001/order -H "Content-Type: application/json" -d '{"orderId":1}'
+```
+
+**Windows (PowerShell):**
+
+```powershell
+Invoke-RestMethod -Method Post -Uri "http://localhost:5001/order" -ContentType "application/json" -Body '{"orderId":1}'
+```
+
+**Any OS (VS Code REST Client):** open [`test.rest`](./test.rest) and click *Send Request* above the request. Requires the [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension.
+
+The expected response is `201 Created` with this body:
+
+```json
+{"orderId":1,"message":"Order created successfully"}
+```
+
+The application logs in the `diagrid dev run` terminal should show an order was saved.
+
+### 6.2 Retrieve state
+
+Confirm the state item was saved successfully by retrieving it:
+
+**macOS/Linux (curl):**
+
+```bash
+curl -i -X GET http://localhost:5001/order/1
+```
+
+**Windows (PowerShell):**
+
+```powershell
+Invoke-RestMethod -Method Get -Uri "http://localhost:5001/order/1"
+```
+
+**Any OS (VS Code REST Client):** open [`test.rest`](./test.rest) and click *Send Request* above the request. Requires the [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension.
+
+The expected response body is:
+
+```json
+{"data":{"orderId":1}}
+```
+
+### 6.3 View in the Catalyst web console
+
+Open the [KV Store data explorer](https://catalyst.diagrid.io/kv-store/kvstore) in the Catalyst Cloud web console (Resources > Managed KV store) and confirm the key-value pair saved by your application appears.
+
+## 7. Clean Up
+
+Press CTRL+C in the terminal that runs `diagrid dev run` to stop the application and disconnect from Catalyst Cloud.
+
+To delete the entire project and all provisioned resources:
+
+```bash
+diagrid project delete state-quickstart
+```
+
+## Summary
+
+In this quickstart you:
+
+- Logged in to Catalyst and provisioned a managed state store project with a single CLI command (`diagrid dev run`).
+- Saved and retrieved state items using the Dapr State API.
+- Inspected stored data using the Catalyst KV Store data explorer.
+
+Catalyst handled state persistence and key-value storage automatically — no infrastructure to manage.
+
+## Next steps
+
+- Explore the [Dapr API SDK guides](https://docs.diagrid.io/develop/dapr-apis) to integrate state management into your own applications.
+- Try the [Pub/Sub quickstart](https://docs.diagrid.io/getting-started/quickstarts/dapr-apis/pubsub) to add event-driven messaging to your application.
+- Read the full [State Management quickstart docs](https://docs.diagrid.io/getting-started/quickstarts/dapr-apis/state).
+- Browse all [Catalyst quickstarts](../../README.md) in this repository.

--- a/state/java/README.md
+++ b/state/java/README.md
@@ -135,12 +135,12 @@ curl -i -X GET http://localhost:5001/order/1
 Invoke-RestMethod -Method Get -Uri "http://localhost:5001/order/1"
 ```
 
-**Any OS (VS Code REST Client):** open [`test.rest`](./test.rest) and click *Send Request* above the request. Requires the [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension.
+**Any OS (VS Code REST Client):** open [`test.rest`](./test.rest) and click *Send Request* above the request. Note that `test.rest` uses order ID `4` rather than `1`, so the retrieved value reads `4`. Requires the [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension.
 
 The expected response body is:
 
 ```json
-{"data":{"orderId":1}}
+{"data":{"orderId":1},"message":""}
 ```
 
 ### 6.3 View in the Catalyst web console

--- a/state/javascript/README.md
+++ b/state/javascript/README.md
@@ -134,7 +134,7 @@ curl -i -X GET http://localhost:5001/order/1
 Invoke-RestMethod -Method Get -Uri "http://localhost:5001/order/1"
 ```
 
-**Any OS (VS Code REST Client):** open [`test.rest`](./test.rest) and click *Send Request* above the request. Requires the [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension.
+**Any OS (VS Code REST Client):** open [`test.rest`](./test.rest) and click *Send Request* above the request. Note that `test.rest` uses order ID `4` rather than `1`, so the retrieved value reads `4`. Requires the [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension.
 
 The expected response body is:
 

--- a/state/javascript/README.md
+++ b/state/javascript/README.md
@@ -1,0 +1,174 @@
+# Quickstart: State Management (JavaScript)
+
+In this quickstart, you'll run a stateful order application on [Catalyst Cloud](https://docs.diagrid.io/operate/hosting/catalyst-cloud). You will learn how to:
+
+- Provision a Catalyst project with a managed KV store using the Diagrid CLI.
+- Save and retrieve state items using the Dapr State API.
+- Inspect stored data in the Catalyst web console.
+
+```mermaid
+---
+title: Order App connected to Catalyst with KV Store
+---
+flowchart LR
+  APP(Order App)
+  subgraph Catalyst
+    APPID(ID: order-app)
+    STATE[(KV Store)]
+  end
+
+  APP<-->APPID
+  APPID<-->STATE
+```
+
+## 1. Prerequisites
+
+Before you proceed, ensure you have the following prerequisites installed.
+
+- [Diagrid Catalyst account](https://catalyst.diagrid.io/)
+- [Diagrid CLI](https://docs.diagrid.io/getting-started/install-cli)
+- [Git](https://git-scm.com/downloads)
+- [Node.JS LTS](https://nodejs.org/en/)
+
+## 2. Log in to Catalyst
+
+Authenticate to Diagrid Catalyst using the following command:
+
+```bash
+diagrid login
+```
+
+This command opens a new browser window where you'll be shown a confirmation code that should match the code in your terminal. Confirm the code, and if you're not logged into Catalyst, you'll be redirected to login.
+
+Confirm your user details are correct using the following command:
+
+```bash
+diagrid whoami
+```
+
+The expected output contains the name of the organization, your user name, and the Catalyst API endpoint.
+
+## 3. Clone Quickstart Code
+
+Clone the quickstart code from GitHub:
+
+```bash
+git clone https://github.com/diagridio/catalyst-quickstarts
+```
+
+Navigate to the quickstart directory:
+
+**macOS/Linux:**
+
+```bash
+cd catalyst-quickstarts/state/javascript
+```
+
+**Windows:**
+
+```powershell
+cd catalyst-quickstarts\state\javascript
+```
+
+## 4. Install Dependencies
+
+Install the dependencies for the state management application.
+
+```bash
+npm install
+```
+
+## 5. Run the application with Catalyst Cloud
+
+The `diagrid dev run` command creates your Catalyst project, provisions resources (apps, Diagrid KV Store service), configures environment variables, and launches your application connected to Catalyst Cloud.
+
+```bash
+diagrid dev run -f state-quickstart.yaml --project state-quickstart --approve
+```
+
+> **Tip:** Wait a few seconds until you see application logs in the terminal to ensure the application is up and running and connected to Catalyst.
+
+## 6. Call the State API
+
+With the quickstart running, test the State API by storing and retrieving a state item.
+
+### 6.1 Store state
+
+Open a new terminal and save a state item to the Diagrid KV store:
+
+**macOS/Linux (curl):**
+
+```bash
+curl -i -X POST http://localhost:5001/order -H "Content-Type: application/json" -d '{"orderId":1}'
+```
+
+**Windows (PowerShell):**
+
+```powershell
+Invoke-RestMethod -Method Post -Uri "http://localhost:5001/order" -ContentType "application/json" -Body '{"orderId":1}'
+```
+
+**Any OS (VS Code REST Client):** open [`test.rest`](./test.rest) and click *Send Request* above the request. Requires the [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension.
+
+The expected response is `201 Created` with this body:
+
+```json
+{"id":1,"message":"Order created successfully"}
+```
+
+The application logs in the `diagrid dev run` terminal should show an order was saved.
+
+### 6.2 Retrieve state
+
+Confirm the state item was saved successfully by retrieving it:
+
+**macOS/Linux (curl):**
+
+```bash
+curl -i -X GET http://localhost:5001/order/1
+```
+
+**Windows (PowerShell):**
+
+```powershell
+Invoke-RestMethod -Method Get -Uri "http://localhost:5001/order/1"
+```
+
+**Any OS (VS Code REST Client):** open [`test.rest`](./test.rest) and click *Send Request* above the request. Requires the [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension.
+
+The expected response body is:
+
+```json
+{"data":{"orderId":1}}
+```
+
+### 6.3 View in the Catalyst web console
+
+Open the [KV Store data explorer](https://catalyst.diagrid.io/kv-store/kvstore) in the Catalyst Cloud web console (Resources > Managed KV store) and confirm the key-value pair saved by your application appears.
+
+## 7. Clean Up
+
+Press CTRL+C in the terminal that runs `diagrid dev run` to stop the application and disconnect from Catalyst Cloud.
+
+To delete the entire project and all provisioned resources:
+
+```bash
+diagrid project delete state-quickstart
+```
+
+## Summary
+
+In this quickstart you:
+
+- Logged in to Catalyst and provisioned a managed state store project with a single CLI command (`diagrid dev run`).
+- Saved and retrieved state items using the Dapr State API.
+- Inspected stored data using the Catalyst KV Store data explorer.
+
+Catalyst handled state persistence and key-value storage automatically — no infrastructure to manage.
+
+## Next steps
+
+- Explore the [Dapr API SDK guides](https://docs.diagrid.io/develop/dapr-apis) to integrate state management into your own applications.
+- Try the [Pub/Sub quickstart](https://docs.diagrid.io/getting-started/quickstarts/dapr-apis/pubsub) to add event-driven messaging to your application.
+- Read the full [State Management quickstart docs](https://docs.diagrid.io/getting-started/quickstarts/dapr-apis/state).
+- Browse all [Catalyst quickstarts](../../README.md) in this repository.

--- a/state/python/README.md
+++ b/state/python/README.md
@@ -153,7 +153,7 @@ curl -i -X GET http://localhost:5001/order/1
 Invoke-RestMethod -Method Get -Uri "http://localhost:5001/order/1"
 ```
 
-**Any OS (VS Code REST Client):** open [`test.rest`](./test.rest) and click *Send Request* above the request. Requires the [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension.
+**Any OS (VS Code REST Client):** open [`test.rest`](./test.rest) and click *Send Request* above the request. Note that `test.rest` uses order ID `4` rather than `1`, so the retrieved value reads `4`. Requires the [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension.
 
 The expected response body is:
 

--- a/state/python/README.md
+++ b/state/python/README.md
@@ -1,0 +1,195 @@
+# Quickstart: State Management (Python)
+
+In this quickstart, you'll run a stateful order application on [Catalyst Cloud](https://docs.diagrid.io/operate/hosting/catalyst-cloud). You will learn how to:
+
+- Provision a Catalyst project with a managed KV store using the Diagrid CLI.
+- Save and retrieve state items using the Dapr State API.
+- Inspect stored data in the Catalyst web console.
+
+```mermaid
+---
+title: Order App connected to Catalyst with KV Store
+---
+flowchart LR
+  APP(Order App)
+  subgraph Catalyst
+    APPID(ID: order-app)
+    STATE[(KV Store)]
+  end
+
+  APP<-->APPID
+  APPID<-->STATE
+```
+
+## 1. Prerequisites
+
+Before you proceed, ensure you have the following prerequisites installed.
+
+- [Diagrid Catalyst account](https://catalyst.diagrid.io/)
+- [Diagrid CLI](https://docs.diagrid.io/getting-started/install-cli)
+- [Git](https://git-scm.com/downloads)
+- [Python 3.12+](https://www.python.org/downloads/) & [uv](https://docs.astral.sh/uv/#installation)
+
+## 2. Log in to Catalyst
+
+Authenticate to Diagrid Catalyst using the following command:
+
+```bash
+diagrid login
+```
+
+This command opens a new browser window where you'll be shown a confirmation code that should match the code in your terminal. Confirm the code, and if you're not logged into Catalyst, you'll be redirected to login.
+
+Confirm your user details are correct using the following command:
+
+```bash
+diagrid whoami
+```
+
+The expected output contains the name of the organization, your user name, and the Catalyst API endpoint.
+
+## 3. Clone Quickstart Code
+
+Clone the quickstart code from GitHub:
+
+```bash
+git clone https://github.com/diagridio/catalyst-quickstarts
+```
+
+Navigate to the quickstart directory:
+
+**macOS/Linux:**
+
+```bash
+cd catalyst-quickstarts/state/python
+```
+
+**Windows:**
+
+```powershell
+cd catalyst-quickstarts\state\python
+```
+
+## 4. Install Dependencies
+
+Install the dependencies for the state management application.
+
+Create and activate a Python virtual environment:
+
+**macOS/Linux:**
+
+```bash
+uv venv
+source .venv/bin/activate
+```
+
+**Windows:**
+
+```powershell
+uv venv
+.venv\Scripts\activate
+# or use .venv\Scripts\Activate.ps1
+```
+
+Install dependencies:
+
+```bash
+uv sync
+```
+
+## 5. Run the application with Catalyst Cloud
+
+The `diagrid dev run` command creates your Catalyst project, provisions resources (apps, Diagrid KV Store service), configures environment variables, and launches your application connected to Catalyst Cloud.
+
+```bash
+diagrid dev run -f state-quickstart.yaml --project state-quickstart --approve
+```
+
+> **Tip:** Wait a few seconds until you see application logs in the terminal to ensure the application is up and running and connected to Catalyst.
+
+## 6. Call the State API
+
+With the quickstart running, test the State API by storing and retrieving a state item.
+
+### 6.1 Store state
+
+Open a new terminal and save a state item to the Diagrid KV store:
+
+**macOS/Linux (curl):**
+
+```bash
+curl -i -X POST http://localhost:5001/order -H "Content-Type: application/json" -d '{"orderId":1}'
+```
+
+**Windows (PowerShell):**
+
+```powershell
+Invoke-RestMethod -Method Post -Uri "http://localhost:5001/order" -ContentType "application/json" -Body '{"orderId":1}'
+```
+
+**Any OS (VS Code REST Client):** open [`test.rest`](./test.rest) and click *Send Request* above the request. Requires the [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension.
+
+The expected response is `201 Created` with this body:
+
+```json
+{"id":1,"message":"Order created successfully"}
+```
+
+The application logs in the `diagrid dev run` terminal should show an order was saved.
+
+### 6.2 Retrieve state
+
+Confirm the state item was saved successfully by retrieving it:
+
+**macOS/Linux (curl):**
+
+```bash
+curl -i -X GET http://localhost:5001/order/1
+```
+
+**Windows (PowerShell):**
+
+```powershell
+Invoke-RestMethod -Method Get -Uri "http://localhost:5001/order/1"
+```
+
+**Any OS (VS Code REST Client):** open [`test.rest`](./test.rest) and click *Send Request* above the request. Requires the [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension.
+
+The expected response body is:
+
+```json
+{"data":"orderId=1"}
+```
+
+This application stores the order as the string form of its model, so the retrieved value reads `orderId=1` rather than a nested JSON object.
+
+### 6.3 View in the Catalyst web console
+
+Open the [KV Store data explorer](https://catalyst.diagrid.io/kv-store/kvstore) in the Catalyst Cloud web console (Resources > Managed KV store) and confirm the key-value pair saved by your application appears.
+
+## 7. Clean Up
+
+Press CTRL+C in the terminal that runs `diagrid dev run` to stop the application and disconnect from Catalyst Cloud.
+
+To delete the entire project and all provisioned resources:
+
+```bash
+diagrid project delete state-quickstart
+```
+
+## Summary
+
+In this quickstart you:
+
+- Logged in to Catalyst and provisioned a managed state store project with a single CLI command (`diagrid dev run`).
+- Saved and retrieved state items using the Dapr State API.
+- Inspected stored data using the Catalyst KV Store data explorer.
+
+Catalyst handled state persistence and key-value storage automatically — no infrastructure to manage.
+
+## Next steps
+
+- Explore the [Dapr API SDK guides](https://docs.diagrid.io/develop/dapr-apis) to integrate state management into your own applications.
+- Try the [Pub/Sub quickstart](https://docs.diagrid.io/getting-started/quickstarts/dapr-apis/pubsub) to add event-driven messaging to your application.
+- Read the full [State Management quickstart docs](https://docs.diagrid.io/getting-started/quickstarts/dapr-apis/state).
+- Browse all [Catalyst quickstarts](../../README.md) in this repository.

--- a/workflow/csharp/README.md
+++ b/workflow/csharp/README.md
@@ -1,0 +1,222 @@
+# Quickstart: Workflow (C#)
+
+In this quickstart, you'll run an order processing workflow on [Catalyst Cloud](https://docs.diagrid.io/operate/hosting/catalyst-cloud). You will learn how to:
+
+- Provision a Catalyst project with a managed workflow engine using the Diagrid CLI.
+- Run a stateful, multi-step order workflow that chains inventory checking, payment processing, and notification activities.
+- Start, monitor, and inspect workflow executions using both the API and the Catalyst web console.
+
+```mermaid
+---
+title: Order Workflow App connected to Catalyst
+---
+flowchart LR
+  APP(Order Workflow App)
+  subgraph Catalyst
+    APPID(ID: order-workflow)
+    WF(Workflow Engine)
+    STATE[(State Store)]
+  end
+
+  APP<-->APPID
+  APPID<-->WF
+  WF<-->STATE
+```
+
+## 1. Prerequisites
+
+Before you proceed, ensure you have the following prerequisites installed.
+
+- [Diagrid Catalyst account](https://catalyst.diagrid.io/)
+- [Diagrid CLI](https://docs.diagrid.io/getting-started/install-cli)
+- [Git](https://git-scm.com/downloads)
+- [.NET 10.0](https://dotnet.microsoft.com/en-us/download)
+
+## 2. Log in to Catalyst
+
+Authenticate to Diagrid Catalyst using the following command:
+
+```bash
+diagrid login
+```
+
+This command opens a new browser window where you'll be shown a confirmation code that should match the code in your terminal. Confirm the code, and if you're not logged into Catalyst, you'll be redirected to login.
+
+Confirm your user details are correct using the following command:
+
+```bash
+diagrid whoami
+```
+
+The expected output contains the name of the organization, your user name, and the Catalyst API endpoint.
+
+## 3. Clone Quickstart Code
+
+Clone the quickstart code from GitHub:
+
+```bash
+git clone https://github.com/diagridio/catalyst-quickstarts
+```
+
+Navigate to the quickstart directory:
+
+**macOS/Linux:**
+
+```bash
+cd catalyst-quickstarts/workflow/csharp
+```
+
+**Windows:**
+
+```powershell
+cd catalyst-quickstarts\workflow\csharp
+```
+
+## 4. Install Dependencies
+
+Install the dependencies for the workflow application.
+
+```bash
+dotnet build
+```
+
+## 5. Run the application with Catalyst Cloud
+
+The `diagrid dev run` command creates your Catalyst project, provisions resources (apps, workflow engine, managed state store), configures environment variables, and launches your application connected to Catalyst Cloud.
+
+```bash
+diagrid dev run -f workflow-quickstart.yaml --project workflow-quickstart --approve
+```
+
+> **Tip:** Wait a few seconds until you see application logs in the terminal to ensure the application is up and running and connected to Catalyst.
+
+## 6. Start and inspect a workflow instance
+
+The **Order Processing** workflow chains notification, inventory, payment, and shipping activities, see the diagram for more details.
+
+```mermaid
+---
+title: Order processing workflow
+---
+flowchart TD
+  START((Start)):::startNode
+  ACT1(Notify: Order Received)
+  ACT2(Reserve Inventory)
+  CHOICE1{Inventory
+  Sufficient?}:::decision
+  ACT3(Notify:
+  Insufficient Inventory)
+  ACT4(Process Payment)
+  ACT5(Update Inventory)
+  CHOICE2{Inventory
+  Update OK?}:::decision
+  ACT6(Notify: Refund Order)
+  ACT7(Notify: Order Completed)
+  END((End)):::endNode
+
+  START-->ACT1
+  ACT1-->ACT2
+  ACT2-->CHOICE1
+  CHOICE1--"No"-->ACT3
+  ACT3-->END
+  CHOICE1--"Yes"-->ACT4
+  ACT4-->ACT5
+  ACT5-->CHOICE2
+  CHOICE2--"Error"-->ACT6
+  ACT6-->END
+  CHOICE2--"Success"-->ACT7
+  ACT7-->END
+
+  classDef startNode stroke:#22613f,stroke-width:3px
+  classDef endNode stroke:#8b1a1a,stroke-width:3px
+  classDef decision stroke:#ed8936
+```
+
+### 6.1 Start workflow
+
+Open a new terminal and start a new workflow by making a POST request to the `start` endpoint:
+
+**macOS/Linux (curl):**
+
+```bash
+curl -i -X POST http://localhost:5001/workflow/start -H "Content-Type: application/json" -d '{"name":"Car", "quantity":2}'
+```
+
+**Windows (PowerShell):**
+
+```powershell
+Invoke-RestMethod -Method Post -Uri "http://localhost:5001/workflow/start" -ContentType "application/json" -Body '{"name":"Car", "quantity":2}'
+```
+
+**Any OS (VS Code REST Client):** open [`test.rest`](./test.rest) and click *Send Request* above the request. Requires the [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension.
+
+The response contains the workflow instance ID:
+
+```json
+{"instanceId":"<YOUR_INSTANCE_ID>"}
+```
+
+Copy the value from the response and save it as an environment variable for subsequent calls:
+
+**macOS/Linux:**
+
+```bash
+export INSTANCE_ID=<YOUR_INSTANCE_ID>
+```
+
+**Windows:**
+
+```powershell
+$env:INSTANCE_ID = "<YOUR_INSTANCE_ID>"
+```
+
+### 6.2 Get workflow status
+
+Get the workflow status by making a GET request to the `status` endpoint and providing the instance ID.
+
+**macOS/Linux (curl):**
+
+```bash
+curl -i -X GET http://localhost:5001/workflow/status/$INSTANCE_ID
+```
+
+**Windows (PowerShell):**
+
+```powershell
+Invoke-RestMethod -Method Get -Uri "http://localhost:5001/workflow/status/$env:INSTANCE_ID" | ConvertTo-Json -Depth 3
+```
+
+**Any OS (VS Code REST Client):** open [`test.rest`](./test.rest) and click *Send Request* above the request — it reuses the instance ID from the start request automatically. Requires the [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension.
+
+The response is a JSON object with a `state` property holding the Dapr `WorkflowState` (runtime status, timestamps, and serialized input and output) and a `result` property holding the workflow's `OrderResult` output. Once the workflow has finished, the runtime status reads as completed.
+
+### 6.3 View in the Catalyst web console
+
+Open the [Workflow viewer](https://catalyst.diagrid.io/workflows/executions) in the Catalyst Cloud web console and select the workflow instance you just started to see a visual execution trace. The viewer displays each activity in sequence, its completion status, and the total workflow duration — useful for debugging long-running or failed executions.
+
+## 7. Clean Up
+
+Press CTRL+C in the terminal that runs `diagrid dev run` to stop the application and disconnect from Catalyst Cloud.
+
+To delete the entire project and all provisioned resources:
+
+```bash
+diagrid project delete workflow-quickstart
+```
+
+## Summary
+
+In this quickstart you:
+
+- Logged in to Catalyst and provisioned a managed workflow project with a single CLI command (`diagrid dev run`).
+- Ran an order processing workflow that's using task chaining.
+- Inspected workflow execution state using the `status` endpoint and the Catalyst web console.
+
+Catalyst handled workflow state durability, activity orchestration, and retries automatically — no infrastructure to manage.
+
+## Next steps
+
+- Explore the [Workflow SDK guides](https://docs.diagrid.io/develop/workflows) for building workflows from scratch, understanding workflow patterns, and resiliency.
+- Try the [Workflow Composer](https://docs.diagrid.io/develop/workflows/workflow-composer) to scaffold workflow projects based on diagrams, or try the [Claude skills for Dapr](https://github.com/diagrid-labs/dapr-skills) to build entire Dapr workflow applications.
+- Read the full [Workflow quickstart docs](https://docs.diagrid.io/getting-started/quickstarts/workflow).
+- Browse all [Catalyst quickstarts](../../README.md) in this repository.

--- a/workflow/java/README.md
+++ b/workflow/java/README.md
@@ -1,0 +1,223 @@
+# Quickstart: Workflow (Java)
+
+In this quickstart, you'll run an order processing workflow on [Catalyst Cloud](https://docs.diagrid.io/operate/hosting/catalyst-cloud). You will learn how to:
+
+- Provision a Catalyst project with a managed workflow engine using the Diagrid CLI.
+- Run a stateful, multi-step order workflow that chains inventory checking, payment processing, and notification activities.
+- Start, monitor, and inspect workflow executions using both the API and the Catalyst web console.
+
+```mermaid
+---
+title: Order Workflow App connected to Catalyst
+---
+flowchart LR
+  APP(Order Workflow App)
+  subgraph Catalyst
+    APPID(ID: order-workflow)
+    WF(Workflow Engine)
+    STATE[(State Store)]
+  end
+
+  APP<-->APPID
+  APPID<-->WF
+  WF<-->STATE
+```
+
+## 1. Prerequisites
+
+Before you proceed, ensure you have the following prerequisites installed.
+
+- [Diagrid Catalyst account](https://catalyst.diagrid.io/)
+- [Diagrid CLI](https://docs.diagrid.io/getting-started/install-cli)
+- [Git](https://git-scm.com/downloads)
+- Java 17+: [OracleJDK](https://www.oracle.com/java/technologies/downloads/) or [OpenJDK](https://jdk.java.net/)
+- [Apache Maven 3.9.5+](https://maven.apache.org/download.cgi)
+
+## 2. Log in to Catalyst
+
+Authenticate to Diagrid Catalyst using the following command:
+
+```bash
+diagrid login
+```
+
+This command opens a new browser window where you'll be shown a confirmation code that should match the code in your terminal. Confirm the code, and if you're not logged into Catalyst, you'll be redirected to login.
+
+Confirm your user details are correct using the following command:
+
+```bash
+diagrid whoami
+```
+
+The expected output contains the name of the organization, your user name, and the Catalyst API endpoint.
+
+## 3. Clone Quickstart Code
+
+Clone the quickstart code from GitHub:
+
+```bash
+git clone https://github.com/diagridio/catalyst-quickstarts
+```
+
+Navigate to the quickstart directory:
+
+**macOS/Linux:**
+
+```bash
+cd catalyst-quickstarts/workflow/java
+```
+
+**Windows:**
+
+```powershell
+cd catalyst-quickstarts\workflow\java
+```
+
+## 4. Install Dependencies
+
+Install the dependencies for the workflow application.
+
+```bash
+mvn clean install
+```
+
+## 5. Run the application with Catalyst Cloud
+
+The `diagrid dev run` command creates your Catalyst project, provisions resources (apps, workflow engine, managed state store), configures environment variables, and launches your application connected to Catalyst Cloud.
+
+```bash
+diagrid dev run --project workflow-quickstart --app-id order-workflow --approve -- mvn spring-boot:run
+```
+
+> **Tip:** Wait a few seconds until you see application logs in the terminal to ensure the application is up and running and connected to Catalyst.
+
+## 6. Start and inspect a workflow instance
+
+The **Order Processing** workflow chains notification, inventory, payment, and shipping activities, see the diagram for more details.
+
+```mermaid
+---
+title: Order processing workflow
+---
+flowchart TD
+  START((Start)):::startNode
+  ACT1(Notify: Order Received)
+  ACT2(Reserve Inventory)
+  CHOICE1{Inventory
+  Sufficient?}:::decision
+  ACT3(Notify:
+  Insufficient Inventory)
+  ACT4(Process Payment)
+  ACT5(Update Inventory)
+  CHOICE2{Inventory
+  Update OK?}:::decision
+  ACT6(Notify: Refund Order)
+  ACT7(Notify: Order Completed)
+  END((End)):::endNode
+
+  START-->ACT1
+  ACT1-->ACT2
+  ACT2-->CHOICE1
+  CHOICE1--"No"-->ACT3
+  ACT3-->END
+  CHOICE1--"Yes"-->ACT4
+  ACT4-->ACT5
+  ACT5-->CHOICE2
+  CHOICE2--"Error"-->ACT6
+  ACT6-->END
+  CHOICE2--"Success"-->ACT7
+  ACT7-->END
+
+  classDef startNode stroke:#22613f,stroke-width:3px
+  classDef endNode stroke:#8b1a1a,stroke-width:3px
+  classDef decision stroke:#ed8936
+```
+
+### 6.1 Start workflow
+
+Open a new terminal and start a new workflow by making a POST request to the `start` endpoint:
+
+**macOS/Linux (curl):**
+
+```bash
+curl -i -X POST http://localhost:5001/workflow/start -H "Content-Type: application/json" -d '{"name":"Car", "quantity":2}'
+```
+
+**Windows (PowerShell):**
+
+```powershell
+Invoke-RestMethod -Method Post -Uri "http://localhost:5001/workflow/start" -ContentType "application/json" -Body '{"name":"Car", "quantity":2}'
+```
+
+**Any OS (VS Code REST Client):** open [`test.rest`](./test.rest) and click *Send Request* above the request. Requires the [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension.
+
+The response contains the workflow instance ID:
+
+```json
+{"instanceId":"<YOUR_INSTANCE_ID>"}
+```
+
+Copy the value from the response and save it as an environment variable for subsequent calls:
+
+**macOS/Linux:**
+
+```bash
+export INSTANCE_ID=<YOUR_INSTANCE_ID>
+```
+
+**Windows:**
+
+```powershell
+$env:INSTANCE_ID = "<YOUR_INSTANCE_ID>"
+```
+
+### 6.2 Get workflow status
+
+Get the workflow status by making a GET request to the `status` endpoint and providing the instance ID.
+
+**macOS/Linux (curl):**
+
+```bash
+curl -i -X GET http://localhost:5001/workflow/status/$INSTANCE_ID
+```
+
+**Windows (PowerShell):**
+
+```powershell
+Invoke-RestMethod -Method Get -Uri "http://localhost:5001/workflow/status/$env:INSTANCE_ID" | ConvertTo-Json -Depth 3
+```
+
+**Any OS (VS Code REST Client):** open [`test.rest`](./test.rest) and click *Send Request* above the request — it reuses the instance ID from the start request automatically. Requires the [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension.
+
+The response is the serialized Dapr `WorkflowInstanceStatus` for the instance, including its runtime status, creation and last-updated timestamps, and the workflow's serialized input and output. Once the workflow has finished, the runtime status reads as completed.
+
+### 6.3 View in the Catalyst web console
+
+Open the [Workflow viewer](https://catalyst.diagrid.io/workflows/executions) in the Catalyst Cloud web console and select the workflow instance you just started to see a visual execution trace. The viewer displays each activity in sequence, its completion status, and the total workflow duration — useful for debugging long-running or failed executions.
+
+## 7. Clean Up
+
+Press CTRL+C in the terminal that runs `diagrid dev run` to stop the application and disconnect from Catalyst Cloud.
+
+To delete the entire project and all provisioned resources:
+
+```bash
+diagrid project delete workflow-quickstart
+```
+
+## Summary
+
+In this quickstart you:
+
+- Logged in to Catalyst and provisioned a managed workflow project with a single CLI command (`diagrid dev run`).
+- Ran an order processing workflow that's using task chaining.
+- Inspected workflow execution state using the `status` endpoint and the Catalyst web console.
+
+Catalyst handled workflow state durability, activity orchestration, and retries automatically — no infrastructure to manage.
+
+## Next steps
+
+- Explore the [Workflow SDK guides](https://docs.diagrid.io/develop/workflows) for building workflows from scratch, understanding workflow patterns, and resiliency.
+- Try the [Workflow Composer](https://docs.diagrid.io/develop/workflows/workflow-composer) to scaffold workflow projects based on diagrams, or try the [Claude skills for Dapr](https://github.com/diagrid-labs/dapr-skills) to build entire Dapr workflow applications.
+- Read the full [Workflow quickstart docs](https://docs.diagrid.io/getting-started/quickstarts/workflow).
+- Browse all [Catalyst quickstarts](../../README.md) in this repository.

--- a/workflow/java/README.md
+++ b/workflow/java/README.md
@@ -154,7 +154,7 @@ Invoke-RestMethod -Method Post -Uri "http://localhost:5001/workflow/start" -Cont
 The response contains the workflow instance ID:
 
 ```json
-{"instanceId":"<YOUR_INSTANCE_ID>"}
+{"instanceId":"<YOUR_INSTANCE_ID>","errorMessage":null}
 ```
 
 Copy the value from the response and save it as an environment variable for subsequent calls:

--- a/workflow/javascript/README.md
+++ b/workflow/javascript/README.md
@@ -186,7 +186,7 @@ curl -i -X GET http://localhost:5001/workflow/status/$INSTANCE_ID
 Invoke-RestMethod -Method Get -Uri "http://localhost:5001/workflow/status/$env:INSTANCE_ID" | ConvertTo-Json -Depth 3
 ```
 
-**Any OS (VS Code REST Client):** open [`test.rest`](./test.rest) and click *Send Request* above the request — it reuses the instance ID from the start request automatically. Requires the [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension.
+**Any OS (VS Code REST Client):** open [`test.rest`](./test.rest), and replace `{{startWorkflow.response.body.instanceId}}` in the status request with the `instance_id` value from step 6.1 — this application returns `instance_id`, so the variable does not resolve on its own. Requires the [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension.
 
 The response is the Dapr SDK's `WorkflowState` object for the instance, including its runtime status and creation and last-updated timestamps. Once the workflow has finished, the runtime status reads as completed.
 

--- a/workflow/javascript/README.md
+++ b/workflow/javascript/README.md
@@ -1,0 +1,222 @@
+# Quickstart: Workflow (JavaScript)
+
+In this quickstart, you'll run an order processing workflow on [Catalyst Cloud](https://docs.diagrid.io/operate/hosting/catalyst-cloud). You will learn how to:
+
+- Provision a Catalyst project with a managed workflow engine using the Diagrid CLI.
+- Run a stateful, multi-step order workflow that chains inventory checking, payment processing, and notification activities.
+- Start, monitor, and inspect workflow executions using both the API and the Catalyst web console.
+
+```mermaid
+---
+title: Order Workflow App connected to Catalyst
+---
+flowchart LR
+  APP(Order Workflow App)
+  subgraph Catalyst
+    APPID(ID: order-workflow)
+    WF(Workflow Engine)
+    STATE[(State Store)]
+  end
+
+  APP<-->APPID
+  APPID<-->WF
+  WF<-->STATE
+```
+
+## 1. Prerequisites
+
+Before you proceed, ensure you have the following prerequisites installed.
+
+- [Diagrid Catalyst account](https://catalyst.diagrid.io/)
+- [Diagrid CLI](https://docs.diagrid.io/getting-started/install-cli)
+- [Git](https://git-scm.com/downloads)
+- [Node.JS LTS](https://nodejs.org/en/)
+
+## 2. Log in to Catalyst
+
+Authenticate to Diagrid Catalyst using the following command:
+
+```bash
+diagrid login
+```
+
+This command opens a new browser window where you'll be shown a confirmation code that should match the code in your terminal. Confirm the code, and if you're not logged into Catalyst, you'll be redirected to login.
+
+Confirm your user details are correct using the following command:
+
+```bash
+diagrid whoami
+```
+
+The expected output contains the name of the organization, your user name, and the Catalyst API endpoint.
+
+## 3. Clone Quickstart Code
+
+Clone the quickstart code from GitHub:
+
+```bash
+git clone https://github.com/diagridio/catalyst-quickstarts
+```
+
+Navigate to the quickstart directory:
+
+**macOS/Linux:**
+
+```bash
+cd catalyst-quickstarts/workflow/javascript
+```
+
+**Windows:**
+
+```powershell
+cd catalyst-quickstarts\workflow\javascript
+```
+
+## 4. Install Dependencies
+
+Install the dependencies for the workflow application.
+
+```bash
+npm install
+```
+
+## 5. Run the application with Catalyst Cloud
+
+The `diagrid dev run` command creates your Catalyst project, provisions resources (apps, workflow engine, managed state store), configures environment variables, and launches your application connected to Catalyst Cloud.
+
+```bash
+diagrid dev run -f workflow-quickstart.yaml --project workflow-quickstart --approve
+```
+
+> **Tip:** Wait a few seconds until you see application logs in the terminal to ensure the application is up and running and connected to Catalyst.
+
+## 6. Start and inspect a workflow instance
+
+The **Order Processing** workflow chains notification, inventory, payment, and shipping activities, see the diagram for more details.
+
+```mermaid
+---
+title: Order processing workflow
+---
+flowchart TD
+  START((Start)):::startNode
+  ACT1(Notify: Order Received)
+  ACT2(Reserve Inventory)
+  CHOICE1{Inventory
+  Sufficient?}:::decision
+  ACT3(Notify:
+  Insufficient Inventory)
+  ACT4(Process Payment)
+  ACT5(Update Inventory)
+  CHOICE2{Inventory
+  Update OK?}:::decision
+  ACT6(Notify: Refund Order)
+  ACT7(Notify: Order Completed)
+  END((End)):::endNode
+
+  START-->ACT1
+  ACT1-->ACT2
+  ACT2-->CHOICE1
+  CHOICE1--"No"-->ACT3
+  ACT3-->END
+  CHOICE1--"Yes"-->ACT4
+  ACT4-->ACT5
+  ACT5-->CHOICE2
+  CHOICE2--"Error"-->ACT6
+  ACT6-->END
+  CHOICE2--"Success"-->ACT7
+  ACT7-->END
+
+  classDef startNode stroke:#22613f,stroke-width:3px
+  classDef endNode stroke:#8b1a1a,stroke-width:3px
+  classDef decision stroke:#ed8936
+```
+
+### 6.1 Start workflow
+
+Open a new terminal and start a new workflow by making a POST request to the `start` endpoint:
+
+**macOS/Linux (curl):**
+
+```bash
+curl -i -X POST http://localhost:5001/workflow/start -H "Content-Type: application/json" -d '{"name":"Car", "quantity":2}'
+```
+
+**Windows (PowerShell):**
+
+```powershell
+Invoke-RestMethod -Method Post -Uri "http://localhost:5001/workflow/start" -ContentType "application/json" -Body '{"name":"Car", "quantity":2}'
+```
+
+**Any OS (VS Code REST Client):** open [`test.rest`](./test.rest) and click *Send Request* above the request. Requires the [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension.
+
+The response contains the workflow instance ID:
+
+```json
+{"instance_id":"<YOUR_INSTANCE_ID>"}
+```
+
+Copy the value from the response and save it as an environment variable for subsequent calls:
+
+**macOS/Linux:**
+
+```bash
+export INSTANCE_ID=<YOUR_INSTANCE_ID>
+```
+
+**Windows:**
+
+```powershell
+$env:INSTANCE_ID = "<YOUR_INSTANCE_ID>"
+```
+
+### 6.2 Get workflow status
+
+Get the workflow status by making a GET request to the `status` endpoint and providing the instance ID.
+
+**macOS/Linux (curl):**
+
+```bash
+curl -i -X GET http://localhost:5001/workflow/status/$INSTANCE_ID
+```
+
+**Windows (PowerShell):**
+
+```powershell
+Invoke-RestMethod -Method Get -Uri "http://localhost:5001/workflow/status/$env:INSTANCE_ID" | ConvertTo-Json -Depth 3
+```
+
+**Any OS (VS Code REST Client):** open [`test.rest`](./test.rest) and click *Send Request* above the request — it reuses the instance ID from the start request automatically. Requires the [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension.
+
+The response is the Dapr SDK's `WorkflowState` object for the instance, including its runtime status and creation and last-updated timestamps. Once the workflow has finished, the runtime status reads as completed.
+
+### 6.3 View in the Catalyst web console
+
+Open the [Workflow viewer](https://catalyst.diagrid.io/workflows/executions) in the Catalyst Cloud web console and select the workflow instance you just started to see a visual execution trace. The viewer displays each activity in sequence, its completion status, and the total workflow duration — useful for debugging long-running or failed executions.
+
+## 7. Clean Up
+
+Press CTRL+C in the terminal that runs `diagrid dev run` to stop the application and disconnect from Catalyst Cloud.
+
+To delete the entire project and all provisioned resources:
+
+```bash
+diagrid project delete workflow-quickstart
+```
+
+## Summary
+
+In this quickstart you:
+
+- Logged in to Catalyst and provisioned a managed workflow project with a single CLI command (`diagrid dev run`).
+- Ran an order processing workflow that's using task chaining.
+- Inspected workflow execution state using the `status` endpoint and the Catalyst web console.
+
+Catalyst handled workflow state durability, activity orchestration, and retries automatically — no infrastructure to manage.
+
+## Next steps
+
+- Explore the [Workflow SDK guides](https://docs.diagrid.io/develop/workflows) for building workflows from scratch, understanding workflow patterns, and resiliency.
+- Try the [Workflow Composer](https://docs.diagrid.io/develop/workflows/workflow-composer) to scaffold workflow projects based on diagrams, or try the [Claude skills for Dapr](https://github.com/diagrid-labs/dapr-skills) to build entire Dapr workflow applications.
+- Read the full [Workflow quickstart docs](https://docs.diagrid.io/getting-started/quickstarts/workflow).
+- Browse all [Catalyst quickstarts](../../README.md) in this repository.

--- a/workflow/python/README.md
+++ b/workflow/python/README.md
@@ -1,0 +1,234 @@
+# Quickstart: Workflow (Python)
+
+In this quickstart, you'll run an order processing workflow on [Catalyst Cloud](https://docs.diagrid.io/operate/hosting/catalyst-cloud). You will learn how to:
+
+- Provision a Catalyst project with a managed workflow engine using the Diagrid CLI.
+- Run a stateful, multi-step order workflow that chains inventory checking, payment processing, and notification activities.
+- Start, monitor, and inspect workflow executions using both the API and the Catalyst web console.
+
+```mermaid
+---
+title: Order Workflow App connected to Catalyst
+---
+flowchart LR
+  APP(Order Workflow App)
+  subgraph Catalyst
+    APPID(ID: order-workflow)
+    WF(Workflow Engine)
+    STATE[(State Store)]
+  end
+
+  APP<-->APPID
+  APPID<-->WF
+  WF<-->STATE
+```
+
+## 1. Prerequisites
+
+Before you proceed, ensure you have the following prerequisites installed.
+
+- [Diagrid Catalyst account](https://catalyst.diagrid.io/)
+- [Diagrid CLI](https://docs.diagrid.io/getting-started/install-cli)
+- [Git](https://git-scm.com/downloads)
+- [Python 3.12+](https://www.python.org/downloads/) & [uv](https://docs.astral.sh/uv/#installation)
+
+## 2. Log in to Catalyst
+
+Authenticate to Diagrid Catalyst using the following command:
+
+```bash
+diagrid login
+```
+
+This command opens a new browser window where you'll be shown a confirmation code that should match the code in your terminal. Confirm the code, and if you're not logged into Catalyst, you'll be redirected to login.
+
+Confirm your user details are correct using the following command:
+
+```bash
+diagrid whoami
+```
+
+The expected output contains the name of the organization, your user name, and the Catalyst API endpoint.
+
+## 3. Clone Quickstart Code
+
+Clone the quickstart code from GitHub:
+
+```bash
+git clone https://github.com/diagridio/catalyst-quickstarts
+```
+
+Navigate to the quickstart directory:
+
+**macOS/Linux:**
+
+```bash
+cd catalyst-quickstarts/workflow/python
+```
+
+**Windows:**
+
+```powershell
+cd catalyst-quickstarts\workflow\python
+```
+
+## 4. Install Dependencies
+
+Install the dependencies for the workflow application.
+
+```bash
+uv sync
+```
+
+## 5. Run the application with Catalyst Cloud
+
+The `diagrid dev run` command creates your Catalyst project, provisions resources (apps, workflow engine, managed state store), configures environment variables, and launches your application connected to Catalyst Cloud.
+
+```bash
+uv run diagrid dev run -f workflow-quickstart.yaml --project workflow-quickstart --approve
+```
+
+> **Tip:** Wait a few seconds until you see application logs in the terminal to ensure the application is up and running and connected to Catalyst.
+
+## 6. Start and inspect a workflow instance
+
+The **Order Processing** workflow chains notification, inventory, payment, and shipping activities, see the diagram for more details.
+
+```mermaid
+---
+title: Order processing workflow
+---
+flowchart TD
+  START((Start)):::startNode
+  ACT1(Notify: Order Received)
+  ACT2(Reserve Inventory)
+  CHOICE1{Inventory
+  Sufficient?}:::decision
+  ACT3(Notify:
+  Insufficient Inventory)
+  ACT4(Process Payment)
+  ACT5(Update Inventory)
+  CHOICE2{Inventory
+  Update OK?}:::decision
+  ACT6(Notify: Refund Order)
+  ACT7(Notify: Order Completed)
+  END((End)):::endNode
+
+  START-->ACT1
+  ACT1-->ACT2
+  ACT2-->CHOICE1
+  CHOICE1--"No"-->ACT3
+  ACT3-->END
+  CHOICE1--"Yes"-->ACT4
+  ACT4-->ACT5
+  ACT5-->CHOICE2
+  CHOICE2--"Error"-->ACT6
+  ACT6-->END
+  CHOICE2--"Success"-->ACT7
+  ACT7-->END
+
+  classDef startNode stroke:#22613f,stroke-width:3px
+  classDef endNode stroke:#8b1a1a,stroke-width:3px
+  classDef decision stroke:#ed8936
+```
+
+### 6.1 Start workflow
+
+Open a new terminal and start a new workflow by making a POST request to the `start` endpoint:
+
+**macOS/Linux (curl):**
+
+```bash
+curl -i -X POST http://localhost:5001/workflow/start -H "Content-Type: application/json" -d '{"name":"Car", "quantity":2}'
+```
+
+**Windows (PowerShell):**
+
+```powershell
+Invoke-RestMethod -Method Post -Uri "http://localhost:5001/workflow/start" -ContentType "application/json" -Body '{"name":"Car", "quantity":2}'
+```
+
+**Any OS (VS Code REST Client):** open [`test.rest`](./test.rest) and click *Send Request* above the request. Requires the [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension.
+
+The response contains the workflow instance ID:
+
+```json
+{"instanceId":"<YOUR_INSTANCE_ID>"}
+```
+
+Copy the value from the response and save it as an environment variable for subsequent calls:
+
+**macOS/Linux:**
+
+```bash
+export INSTANCE_ID=<YOUR_INSTANCE_ID>
+```
+
+**Windows:**
+
+```powershell
+$env:INSTANCE_ID = "<YOUR_INSTANCE_ID>"
+```
+
+### 6.2 Get workflow status
+
+Get the workflow status by making a GET request to the `status` endpoint and providing the instance ID.
+
+**macOS/Linux (curl):**
+
+```bash
+curl -i -X GET http://localhost:5001/workflow/status/$INSTANCE_ID
+```
+
+**Windows (PowerShell):**
+
+```powershell
+Invoke-RestMethod -Method Get -Uri "http://localhost:5001/workflow/status/$env:INSTANCE_ID" | ConvertTo-Json -Depth 3
+```
+
+**Any OS (VS Code REST Client):** open [`test.rest`](./test.rest) and click *Send Request* above the request — it reuses the instance ID from the start request automatically. Requires the [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension.
+
+The response is a JSON structure that is similar to this:
+
+```json
+{
+    "exists":true,
+    "isWorkflowRunning":false,
+    "isWorkflowCompleted":true,
+    "createdAt":"<DATE_TIME>",
+    "lastUpdatedAt":"<DATE_TIME>",
+    "runtimeStatus":1,
+    "failureDetails":null
+}
+```
+
+### 6.3 View in the Catalyst web console
+
+Open the [Workflow viewer](https://catalyst.diagrid.io/workflows/executions) in the Catalyst Cloud web console and select the workflow instance you just started to see a visual execution trace. The viewer displays each activity in sequence, its completion status, and the total workflow duration — useful for debugging long-running or failed executions.
+
+## 7. Clean Up
+
+Press CTRL+C in the terminal that runs `diagrid dev run` to stop the application and disconnect from Catalyst Cloud.
+
+To delete the entire project and all provisioned resources:
+
+```bash
+diagrid project delete workflow-quickstart
+```
+
+## Summary
+
+In this quickstart you:
+
+- Logged in to Catalyst and provisioned a managed workflow project with a single CLI command (`diagrid dev run`).
+- Ran an order processing workflow that's using task chaining.
+- Inspected workflow execution state using the `status` endpoint and the Catalyst web console.
+
+Catalyst handled workflow state durability, activity orchestration, and retries automatically — no infrastructure to manage.
+
+## Next steps
+
+- Explore the [Workflow SDK guides](https://docs.diagrid.io/develop/workflows) for building workflows from scratch, understanding workflow patterns, and resiliency.
+- Try the [Workflow Composer](https://docs.diagrid.io/develop/workflows/workflow-composer) to scaffold workflow projects based on diagrams, or try the [Claude skills for Dapr](https://github.com/diagrid-labs/dapr-skills) to build entire Dapr workflow applications.
+- Read the full [Workflow quickstart docs](https://docs.diagrid.io/getting-started/quickstarts/workflow).
+- Browse all [Catalyst quickstarts](../../README.md) in this repository.


### PR DESCRIPTION
## Summary

The `workflow/`, `invocation/`, `state/`, and `pubsub/` quickstart directories had runnable code but no instructions — a user landing on one from GitHub had to leave for the docs site. This adds 16 self-contained READMEs, one per language directory.

Each is a flattened rendering of its authoritative Docusaurus MDX page in the `diagrid/docs` repo: `<Tabs groupId="language">` disappears (one file per language), `<Tabs groupId="os">` becomes bold labels, `:::tip` becomes a `> **Tip:**` blockquote, screenshots become console links, and relative Docusaurus paths become absolute `docs.diagrid.io` URLs. Mermaid diagrams are kept — GitHub renders them natively.

## Verified against the repo, not copied from the docs

Every command, endpoint, and response body was checked against the application source. Where the docs pages disagreed with the code, the code won:

- **Python 3.12+** and **Java 17+**, not the docs' 3.11+/11.0+ (`requires-python = ">=3.12"`, `<java.version>17</java.version>`).
- **state**: `POST /order` returns **201** with a body, and `GET /order/1` returns a `data` envelope — the docs page claims a bare `200 OK` and `{"orderId":1}`.
- **state/java**: create response uses `orderId` where the other three use `id`; its retrieve response includes `"message":""` because `DataResponse` is a record implementing `getMessage()` (verified by running Jackson against the project's own classpath).
- **state/python**: retrieve returns `{"data":"orderId=1"}` — the app saves `str(order)` rather than JSON.
- **pubsub/java**: `"id"` is a quoted string; the other three return a number.
- **workflow/javascript**: start returns `instance_id`, not `instanceId` like the other three.
- **workflow** status responses differ per language, so only the Python file carries a sample JSON body; the other three describe the response in prose rather than inventing one.

## Two deliberate asymmetries

- `state/` uses `-f state-quickstart.yaml` for all four languages **including Java**, unlike the docs page's `--app-id order-app` form — that form bypasses the yaml and its `resourcesPaths: [statestore.yaml]`, so the KV store component would never be provisioned.
- `workflow/java` does use `--app-id`, because `workflow/java/workflow-quickstart.yaml` genuinely does not exist.

## Known issues this PR documents but does not fix

- `state/java/src/main/java/com/service/controller/Controller.java:27` defaults `STATESTORE_NAME` to `"kvstore"` while the other three default to `"statestore"` and the yaml provisions `statestore` with no `env:` override. Commit af86ce0 appears to have missed Java. **This may prevent the state/java quickstart from completing.**
- `workflow/javascript/test.rest` references `{{startWorkflow.response.body.instanceId}}`, which never resolves because that app returns `instance_id`. The README now tells the reader to substitute the value manually.
- The state READMEs' console link matches the docs page (`/kv-store/kvstore`), but the `-f` flow provisions a connection named `statestore`, so the link may point at the wrong store. Left aligned with the docs deliberately.
- The state docs page's `--app-id` command and response bodies should be corrected separately.

## Scope

Documentation only. No changes to application source, `*-quickstart.yaml`, component yaml, `test.rest`, or the root `README.md` — which already links to all 16 directories, so each begins rendering its README on GitHub with no edit needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)