### PR TITLE
fix: provision managed workflow/KV explicitly in Spring AI quickstart

### DIFF
--- a/agents/spring-ai/crash-recovery/README.md
+++ b/agents/spring-ai/crash-recovery/README.md
@@ -49,11 +49,11 @@ $env:OPENAI_API_KEY = "your-key-here"
 
 ### 1. Deploy and Run
 
-Log in, create the Catalyst project with agent infrastructure enabled (and set it as the default for this session), register the agent, then run:
+Log in, create the Catalyst project with managed workflow enabled (and set it as the default for this session), register the agent, then run:
 
 ```bash
 diagrid login
-diagrid project create spring-ai-crash-recovery --enable-agent-infrastructure --wait --use
+diagrid project create spring-ai-crash-recovery --enable-managed-workflow --wait --use
 diagrid agent create spring-ai-crash-recovery --wait
 diagrid dev run -f dev-spring-ai-crash-recovery.yaml --approve
 ```

--- a/agents/spring-ai/durable-memory/README.md
+++ b/agents/spring-ai/durable-memory/README.md
@@ -36,7 +36,7 @@ export OPENAI_API_KEY="your-key-here"   # PowerShell: $env:OPENAI_API_KEY = "you
 
 ```bash
 diagrid login
-diagrid project create spring-ai-durable-memory --enable-agent-infrastructure --wait --use
+diagrid project create spring-ai-durable-memory --enable-managed-workflow --deploy-managed-kv --wait --use
 diagrid agent create spring-ai-durable-memory --wait
 diagrid dev run -f dev-spring-ai-durable-memory.yaml --approve
 ```
@@ -121,8 +121,8 @@ written in the `after` phase, is recorded once — on success.
 - On a crash or a `DurableCallTimeoutException`, the `after` phase never runs. The workflow is durable;
   the caller-side advisor response phase is not. Re-attaching with the same instance id
   (`DurableAdvisor.INSTANCE_ID_KEY`) is what lets the full chain complete.
-- Chat memory is backed by the Catalyst-managed `agent-memory` store via `dapr-spring-ai-memory`
-  (`dapr.spring-ai.memory.statestore=agent-memory`).
+- Chat memory is backed by the Catalyst-managed `kvstore` store via `dapr-spring-ai-memory`
+  (`dapr.spring-ai.memory.statestore=kvstore`).
 
 > **Design takeaway.** Put anything that must survive a crash *inside* the workflow — as a `@Tool`
 > activity, whose result is checkpointed. Advisor response-phase side effects (memory, logging,

--- a/agents/spring-ai/durable-memory/pom.xml
+++ b/agents/spring-ai/durable-memory/pom.xml
@@ -73,7 +73,7 @@
       <version>${dapr-spring-ai.version}</version>
     </dependency>
 
-    <!-- Chat memory backed by a Dapr state store (the Catalyst-managed 'agent-memory' store). Backs
+    <!-- Chat memory backed by a Dapr state store (the Catalyst-managed 'kvstore' store). Backs
          Spring AI's ChatMemory so MessageChatMemoryAdvisor persists conversations durably. -->
     <dependency>
       <groupId>io.diagrid.dapr</groupId>

--- a/agents/spring-ai/durable-memory/src/main/resources/application.properties
+++ b/agents/spring-ai/durable-memory/src/main/resources/application.properties
@@ -18,10 +18,10 @@ dapr.spring-ai.completion-timeout=2m
 crash-recovery.delay-seconds=30
 
 # ── Chat memory (dapr-spring-ai-memory) ──────────────────────────────────────
-# Back Spring AI's ChatMemory with a Dapr state store so conversations persist. 'agent-memory' is the
-# memory store Catalyst provides out of the box.
+# Back Spring AI's ChatMemory with a Dapr state store so conversations persist. 'kvstore' is the
+# default Diagrid-managed KV store (provisioned by --deploy-managed-kv).
 dapr.spring-ai.memory.enabled=true
-dapr.spring-ai.memory.statestore=agent-memory
+dapr.spring-ai.memory.statestore=kvstore
 
 # ── LLM: OpenAI via Spring AI ────────────────────────────────────────────────
 # Export OPENAI_API_KEY in the environment. Swap the model freely.

--- a/agents/spring-ai/event-planner/README.md
+++ b/agents/spring-ai/event-planner/README.md
@@ -49,11 +49,11 @@ $env:OPENAI_API_KEY = "your-key-here"
 
 ### 1. Deploy and Run
 
-Log in, create the Catalyst project with agent infrastructure enabled (and set it as the default for this session), register the agent, then run:
+Log in, create the Catalyst project with managed workflow enabled (and set it as the default for this session), register the agent, then run:
 
 ```bash
 diagrid login
-diagrid project create spring-ai-quickstart --enable-agent-infrastructure --wait --use
+diagrid project create spring-ai-quickstart --enable-managed-workflow --wait --use
 diagrid agent create spring-ai-event-planner --wait
 diagrid dev run -f dev-spring-ai-event-planner.yaml --approve
 ```


### PR DESCRIPTION
## Summary

The Spring AI quickstart's project setup used `--enable-agent-infrastructure`, which no longer provisions the managed workflow store. Running `diagrid dev run` failed with:

> FAILED_PRECONDITION: Workflow API has not been configured. To use the Workflow API, enable managed workflow for the project or create a state component with workflow support and set actorStateStore=true.

This switches the three modules' `project create` commands to the granular provisioning flags:

- **event-planner**, **crash-recovery** (workflow only): `--enable-managed-workflow`
- **durable-memory** (workflow + KV): `--enable-managed-workflow --deploy-managed-kv`, and its chat-memory store renamed `agent-memory` → `kvstore` (the default Diagrid-managed KV store name).

## Test plan

- [x] `event-planner` verified live on Catalyst with the new flow (project recreated with `--enable-managed-workflow`; workflow resumes on restart with no re-trigger).
- [x] `crash-recovery` — same workflow-only flow as event-planner (re-attach by instance id, no double booking).
- [x] `durable-memory` — confirm `--deploy-managed-kv` provisions a component named `kvstore` and chat memory persists across the crash / re-attach flow.
