### PR TITLE
chore: rename to io.diagrid:diagrid-spring-ai coordinates

### DIFF
--- a/agents/spring-ai/README.md
+++ b/agents/spring-ai/README.md
@@ -1,7 +1,7 @@
 # Spring AI Quickstarts
 
 Build **durable [Spring AI](https://docs.spring.io/spring-ai/reference/) agents** on Diagrid Catalyst
-using the `io.diagrid.dapr:dapr-spring-ai-starter` package.
+using the `io.diagrid:diagrid-spring-ai-starter` package.
 
 The key idea: an ordinary Spring AI app — a `ChatClient` plus `@Tool` beans — becomes **durable across
 restarts purely by adding the starter to the classpath**. There is no durability code in your app. With
@@ -31,7 +31,7 @@ Each quickstart has its own README with the full run steps.
 
 ## How durability works
 
-- `dapr-spring-ai-starter` auto-configures a `DurableAdvisor` (attached to every `ChatClient` built
+- `diagrid-spring-ai-starter` auto-configures a `DurableAdvisor` (attached to every `ChatClient` built
   from the injected `ChatClient.Builder`) and an in-process Dapr Workflow worker.
 - Each `ChatClient.call()` becomes a Dapr Workflow; the model turn and each `@Tool` call run as
   separate checkpointed activities.

--- a/agents/spring-ai/crash-recovery/README.md
+++ b/agents/spring-ai/crash-recovery/README.md
@@ -1,7 +1,7 @@
 # Spring AI Quickstart - Crash Recovery
 
 This quickstart demonstrates how to recover a durable [Spring AI](https://docs.spring.io/spring-ai/reference/)
-agent from a hard crash using the `io.diagrid.dapr:dapr-spring-ai-starter` package. A booking agent
+agent from a hard crash using the `io.diagrid:diagrid-spring-ai-starter` package. A booking agent
 schedules its work under an **instance id you own**, so if the app is killed mid-call you can re-issue
 the same request and **attach** to the still-running workflow instead of starting a second booking.
 

--- a/agents/spring-ai/crash-recovery/pom.xml
+++ b/agents/spring-ai/crash-recovery/pom.xml
@@ -21,7 +21,7 @@
     <java.version>21</java.version>
     <spring-ai.version>2.0.0</spring-ai.version>
     <dapr.version>1.18.0</dapr.version>
-    <dapr-spring-ai.version>0.1.0</dapr-spring-ai.version>
+    <diagrid-spring-ai.version>0.1.0</diagrid-spring-ai.version>
   </properties>
 
   <dependencyManagement>
@@ -69,9 +69,9 @@
     <!-- Durability. This quickstart also uses the library API directly (DurableAdvisor.INSTANCE_ID_KEY,
          DurableCallTimeoutException) to schedule under a caller-owned instance id. -->
     <dependency>
-      <groupId>io.diagrid.dapr</groupId>
-      <artifactId>dapr-spring-ai-starter</artifactId>
-      <version>${dapr-spring-ai.version}</version>
+      <groupId>io.diagrid</groupId>
+      <artifactId>diagrid-spring-ai-starter</artifactId>
+      <version>${diagrid-spring-ai.version}</version>
     </dependency>
   </dependencies>
 

--- a/agents/spring-ai/crash-recovery/src/main/java/io/diagrid/quickstart/springai/crashrecovery/CrashRecoveryController.java
+++ b/agents/spring-ai/crash-recovery/src/main/java/io/diagrid/quickstart/springai/crashrecovery/CrashRecoveryController.java
@@ -1,7 +1,7 @@
 package io.diagrid.quickstart.springai.crashrecovery;
 
-import io.diagrid.dapr.springai.durable.boot.DurableAdvisor;
-import io.diagrid.dapr.springai.durable.client.DurableCallTimeoutException;
+import io.diagrid.springai.durable.boot.DurableAdvisor;
+import io.diagrid.springai.durable.client.DurableCallTimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ai.chat.client.ChatClient;

--- a/agents/spring-ai/crash-recovery/src/main/resources/application.properties
+++ b/agents/spring-ai/crash-recovery/src/main/resources/application.properties
@@ -7,14 +7,14 @@ spring.application.name=spring-ai-crash-recovery
 # virtual thread instead of a platform one.
 spring.threads.virtual.enabled=true
 
-# ── Durability (dapr-spring-ai) ──────────────────────────────────────────────
+# ── Durability (diagrid-spring-ai) ──────────────────────────────────────────────
 # Each ChatClient.call() runs as a Dapr Workflow. On Catalyst the workflow state store is managed for
 # you (no component YAML needed). completion-timeout is the wait budget for the blocking call: kept
 # generous (> the slow tool's ~30s) so the first /crash/book blocks through the crash window. If it
 # elapses the workflow keeps running and the call throws DurableCallTimeoutException with the instance
 # id — re-issue the same id to attach.
-dapr.spring-ai.enabled=true
-dapr.spring-ai.completion-timeout=2m
+diagrid.spring-ai.enabled=true
+diagrid.spring-ai.completion-timeout=2m
 
 # How long commitReservation "commits" for — the window in which you kill the app.
 crash-recovery.delay-seconds=30

--- a/agents/spring-ai/durable-memory/README.md
+++ b/agents/spring-ai/durable-memory/README.md
@@ -1,8 +1,8 @@
 # Spring AI Quickstart - Durable Memory
 
 This quickstart shows **what durability does and does not cover** when you combine the
-`dapr-spring-ai-starter` with Spring AI's memory. It is a durable chat agent whose conversation is
-persisted with a `MessageChatMemoryAdvisor` backed by the `dapr-spring-ai-memory` Dapr state store.
+`diagrid-spring-ai-starter` with Spring AI's memory. It is a durable chat agent whose conversation is
+persisted with a `MessageChatMemoryAdvisor` backed by the `diagrid-spring-ai-memory` Dapr state store.
 
 The key lesson: **Spring AI runs advisors synchronously, and an advisor's response phase runs only
 after a successful call.** The durable Dapr Workflow (the model call and each `@Tool` call) survives a
@@ -113,7 +113,7 @@ written in the `after` phase, is recorded once — on success.
 
 ## How It Works
 
-- `DurableAdvisor` (from `dapr-spring-ai-starter`) is a **terminal** advisor: it runs the model + tool
+- `DurableAdvisor` (from `diagrid-spring-ai-starter`) is a **terminal** advisor: it runs the model + tool
   loop as a Dapr Workflow and returns, short-circuiting the chain. That workflow is what's durable.
 - `MessageChatMemoryAdvisor` sits **before** it in the chain. Its `before` phase (retrieve history, add
   the user message) runs on the caller thread going in; its `after` phase (add the assistant reply)
@@ -121,8 +121,8 @@ written in the `after` phase, is recorded once — on success.
 - On a crash or a `DurableCallTimeoutException`, the `after` phase never runs. The workflow is durable;
   the caller-side advisor response phase is not. Re-attaching with the same instance id
   (`DurableAdvisor.INSTANCE_ID_KEY`) is what lets the full chain complete.
-- Chat memory is backed by the Catalyst-managed `kvstore` store via `dapr-spring-ai-memory`
-  (`dapr.spring-ai.memory.statestore=kvstore`).
+- Chat memory is backed by the Catalyst-managed `kvstore` store via `diagrid-spring-ai-memory`
+  (`diagrid.spring-ai.memory.statestore=kvstore`).
 
 > **Design takeaway.** Put anything that must survive a crash *inside* the workflow — as a `@Tool`
 > activity, whose result is checkpointed. Advisor response-phase side effects (memory, logging,

--- a/agents/spring-ai/durable-memory/pom.xml
+++ b/agents/spring-ai/durable-memory/pom.xml
@@ -21,7 +21,7 @@
     <java.version>21</java.version>
     <spring-ai.version>2.0.0</spring-ai.version>
     <dapr.version>1.18.0</dapr.version>
-    <dapr-spring-ai.version>0.1.0</dapr-spring-ai.version>
+    <diagrid-spring-ai.version>0.1.0</diagrid-spring-ai.version>
   </properties>
 
   <dependencyManagement>
@@ -68,17 +68,17 @@
 
     <!-- Durability: each ChatClient.call() runs as a Dapr Workflow. -->
     <dependency>
-      <groupId>io.diagrid.dapr</groupId>
-      <artifactId>dapr-spring-ai-starter</artifactId>
-      <version>${dapr-spring-ai.version}</version>
+      <groupId>io.diagrid</groupId>
+      <artifactId>diagrid-spring-ai-starter</artifactId>
+      <version>${diagrid-spring-ai.version}</version>
     </dependency>
 
     <!-- Chat memory backed by a Dapr state store (the Catalyst-managed 'kvstore' store). Backs
          Spring AI's ChatMemory so MessageChatMemoryAdvisor persists conversations durably. -->
     <dependency>
-      <groupId>io.diagrid.dapr</groupId>
-      <artifactId>dapr-spring-ai-memory</artifactId>
-      <version>${dapr-spring-ai.version}</version>
+      <groupId>io.diagrid</groupId>
+      <artifactId>diagrid-spring-ai-memory</artifactId>
+      <version>${diagrid-spring-ai.version}</version>
     </dependency>
   </dependencies>
 

--- a/agents/spring-ai/durable-memory/src/main/java/io/diagrid/quickstart/springai/durablememory/MemoryChatController.java
+++ b/agents/spring-ai/durable-memory/src/main/java/io/diagrid/quickstart/springai/durablememory/MemoryChatController.java
@@ -1,7 +1,7 @@
 package io.diagrid.quickstart.springai.durablememory;
 
-import io.diagrid.dapr.springai.durable.boot.DurableAdvisor;
-import io.diagrid.dapr.springai.durable.client.DurableCallTimeoutException;
+import io.diagrid.springai.durable.boot.DurableAdvisor;
+import io.diagrid.springai.durable.client.DurableCallTimeoutException;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/agents/spring-ai/durable-memory/src/main/resources/application.properties
+++ b/agents/spring-ai/durable-memory/src/main/resources/application.properties
@@ -7,21 +7,21 @@ spring.application.name=spring-ai-durable-memory
 # thread instead of a platform one.
 spring.threads.virtual.enabled=true
 
-# ── Durability (dapr-spring-ai) ──────────────────────────────────────────────
+# ── Durability (diagrid-spring-ai) ──────────────────────────────────────────────
 # Each ChatClient.call() runs as a Dapr Workflow. completion-timeout is the wait budget for the
 # blocking call — kept generous (> the slow tool's ~30s) so the first /chat blocks through the crash
 # window; if it elapses the call throws DurableCallTimeoutException and you re-issue the same id.
-dapr.spring-ai.enabled=true
-dapr.spring-ai.completion-timeout=2m
+diagrid.spring-ai.enabled=true
+diagrid.spring-ai.completion-timeout=2m
 
 # How long commitReservation "commits" for — the window in which you kill the app.
 crash-recovery.delay-seconds=30
 
-# ── Chat memory (dapr-spring-ai-memory) ──────────────────────────────────────
+# ── Chat memory (diagrid-spring-ai-memory) ──────────────────────────────────────
 # Back Spring AI's ChatMemory with a Dapr state store so conversations persist. 'kvstore' is the
 # default Diagrid-managed KV store (provisioned by --deploy-managed-kv).
-dapr.spring-ai.memory.enabled=true
-dapr.spring-ai.memory.statestore=kvstore
+diagrid.spring-ai.memory.enabled=true
+diagrid.spring-ai.memory.statestore=kvstore
 
 # ── LLM: OpenAI via Spring AI ────────────────────────────────────────────────
 # Export OPENAI_API_KEY in the environment. Swap the model freely.

--- a/agents/spring-ai/event-planner/README.md
+++ b/agents/spring-ai/event-planner/README.md
@@ -1,7 +1,7 @@
 # Spring AI Quickstart - Event Planner
 
 This quickstart demonstrates how to run a [Spring AI](https://docs.spring.io/spring-ai/reference/)
-agent as a durable Dapr Workflow using the `io.diagrid.dapr:dapr-spring-ai-starter` package. The agent
+agent as a durable Dapr Workflow using the `io.diagrid:diagrid-spring-ai-starter` package. The agent
 acts as an **Event Planner** with three tools that it calls in sequence — tool 2 deliberately crashes
 the process to demonstrate automatic recovery.
 
@@ -122,7 +122,7 @@ and execution continues from `step_two_compare`:
 
 ## How It Works
 
-- `dapr-spring-ai-starter` auto-configures a `DurableAdvisor` (attached to every `ChatClient` built
+- `diagrid-spring-ai-starter` auto-configures a `DurableAdvisor` (attached to every `ChatClient` built
   from the injected `ChatClient.Builder`) and an in-process Dapr Workflow worker.
 - Each `ChatClient.call()` runs as a Dapr Workflow; the model turn and each `@Tool` call run as
   separate **checkpointed activities**. A crash resumes from the last completed step — completed

--- a/agents/spring-ai/event-planner/pom.xml
+++ b/agents/spring-ai/event-planner/pom.xml
@@ -21,7 +21,7 @@
     <java.version>21</java.version>
     <spring-ai.version>2.0.0</spring-ai.version>
     <dapr.version>1.18.0</dapr.version>
-    <dapr-spring-ai.version>0.1.0</dapr-spring-ai.version>
+    <diagrid-spring-ai.version>0.1.0</diagrid-spring-ai.version>
   </properties>
 
   <dependencyManagement>
@@ -70,9 +70,9 @@
          Every ChatClient.call() then runs as a Dapr Workflow whose model turns and tool calls are
          checkpointed activities — so a crash resumes from the last completed step. -->
     <dependency>
-      <groupId>io.diagrid.dapr</groupId>
-      <artifactId>dapr-spring-ai-starter</artifactId>
-      <version>${dapr-spring-ai.version}</version>
+      <groupId>io.diagrid</groupId>
+      <artifactId>diagrid-spring-ai-starter</artifactId>
+      <version>${diagrid-spring-ai.version}</version>
     </dependency>
   </dependencies>
 

--- a/agents/spring-ai/event-planner/src/main/java/io/diagrid/quickstart/springai/eventplanner/EventPlannerController.java
+++ b/agents/spring-ai/event-planner/src/main/java/io/diagrid/quickstart/springai/eventplanner/EventPlannerController.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 /**
  * Ordinary Spring AI usage — no durability code. The {@link ChatClient} is built from the injected
- * {@link ChatClient.Builder}, which lets the dapr-spring-ai {@code DurableAdvisor} attach automatically.
+ * {@link ChatClient.Builder}, which lets the diagrid-spring-ai {@code DurableAdvisor} attach automatically.
  * Every {@code chatClient...call()} then runs as a Dapr Workflow: the model turns and each tool call
  * are checkpointed activities, so a crash resumes from the last completed step.
  *

--- a/agents/spring-ai/event-planner/src/main/java/io/diagrid/quickstart/springai/eventplanner/EventPlannerTools.java
+++ b/agents/spring-ai/event-planner/src/main/java/io/diagrid/quickstart/springai/eventplanner/EventPlannerTools.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 
 /**
  * The Event Planner's three tools, which the agent calls in sequence. These are plain Spring AI
- * {@code @Tool} methods — there is no durability code here. Because the {@code dapr-spring-ai-starter}
+ * {@code @Tool} methods — there is no durability code here. Because the {@code diagrid-spring-ai-starter}
  * is on the classpath, each call runs as a checkpointed Dapr Workflow activity.
  *
  * <p><b>Why a {@code @Tool} Spring bean</b> (and not a per-call {@code .defaultTools(new ...)}): the

--- a/agents/spring-ai/event-planner/src/main/resources/application.properties
+++ b/agents/spring-ai/event-planner/src/main/resources/application.properties
@@ -7,13 +7,13 @@ spring.application.name=spring-ai-event-planner
 # workflow) parks a virtual thread instead of a platform one.
 spring.threads.virtual.enabled=true
 
-# ── Durability (dapr-spring-ai) ──────────────────────────────────────────────
+# ── Durability (diagrid-spring-ai) ──────────────────────────────────────────────
 # Each ChatClient.call() runs as a Dapr Workflow. On Catalyst the workflow state store is managed for
 # you (no component YAML needed). These are the defaults, shown for clarity. completion-timeout is the
 # wait budget for the blocking call; if it elapses the workflow keeps running and the call throws
 # DurableCallTimeoutException with the instance id.
-dapr.spring-ai.enabled=true
-dapr.spring-ai.completion-timeout=5m
+diagrid.spring-ai.enabled=true
+diagrid.spring-ai.completion-timeout=5m
 
 # ── LLM: OpenAI via Spring AI ────────────────────────────────────────────────
 # Export OPENAI_API_KEY in the environment. Swap the model freely.


### PR DESCRIPTION
## Summary

The Spring AI durability library was re-released under new coordinates — `io.diagrid:diagrid-spring-ai-*:0.1.0` is now live on Maven Central. (The old `io.diagrid.dapr:dapr-spring-ai-*` remains on Central but should not be referenced in new content.)

This updates all three `agents/spring-ai/` quickstarts (event-planner, crash-recovery, durable-memory) to the new coordinates:

- **groupId** `io.diagrid.dapr` → `io.diagrid`
- **artifactId** `dapr-spring-ai-{starter,memory}` → `diagrid-spring-ai-*`
- **version property** `<dapr-spring-ai.version>` → `<diagrid-spring-ai.version>` (value unchanged, `0.1.0`)
- **config prefix** `dapr.spring-ai.*` → `diagrid.spring-ai.*` — every key: `enabled`, `completion-timeout`, and durable-memory's `memory.enabled` / `memory.statestore` (unknown `dapr.spring-ai.*` keys fail silently, so none are left behind)
- **import packages** `io.diagrid.dapr.springai.durable.*` → `io.diagrid.springai.durable.*`
- README prose + javadoc mentions

Unchanged on purpose: the quickstart's own `io.diagrid.quickstart.springai` package, the Spring AI BOM (`spring-ai-bom`), the `DurableAdvisor` / `DurableCallTimeoutException` class names, and the `kvstore` state store name.

Pairs with diagridio/docs#1137.

## Test plan

- [x] `git grep -E 'dapr-spring-ai|io\.diagrid\.dapr|dapr\.spring-ai|dapr\.springai'` → no hits
- [x] `mvn -B clean compile` for all three modules → **BUILD SUCCESS**, resolving `io.diagrid:diagrid-spring-ai-*:0.1.0` from Central
- [ ] Optional: end-to-end run on Catalyst (`diagrid dev run`) per module
