### PR TITLE
Register the Spring AI event-planner agent with Catalyst

### DIFF
--- a/agents/spring-ai/README.md
+++ b/agents/spring-ai/README.md
@@ -17,7 +17,7 @@ starting over. On Catalyst the workflow state store is managed for you — no co
 | [crash-recovery](crash-recovery/) | The idempotency story: schedules under a **caller-owned instance id**. Kill the app mid-booking, restart, and re-issue the same id — the call **attaches** to the resumed run and returns the same confirmation code instead of booking twice. |
 | [durable-memory](durable-memory/) | Where the durability boundary sits: durable chat with a `MessageChatMemoryAdvisor`. Spring AI runs advisors **synchronously**, so the memory advisor's response phase (saving the answer) runs only **after a successful call** — a crash keeps the workflow but not the answer, until you re-attach. |
 
-Start with **event-planner** for the "add one dependency, get durability" experience, then
+Start with **event-planner** for the "add the starter, get durability" experience, then
 **crash-recovery** to make a side-effecting tool safe to retry, then **durable-memory** to see where
 the durability boundary sits — the workflow, not Spring AI's caller-side advisor chain.
 
@@ -33,6 +33,10 @@ Each quickstart has its own README with the full run steps.
 
 - `diagrid-spring-ai-starter` auto-configures a `DurableAdvisor` (attached to every `ChatClient` built
   from the injected `ChatClient.Builder`) and an in-process Dapr Workflow worker.
+- Declaring the client as a `ChatClient` **bean** upgrades that: the starter attaches a *per-agent*
+  advisor and names the workflow after the bean (`spring-ai.<beanName>.workflow`) instead of the shared
+  `spring-ai.workflow`. **event-planner** and **crash-recovery** do this; **durable-memory** builds its
+  client from the injected builder and takes the generic path.
 - Each `ChatClient.call()` becomes a Dapr Workflow; the model turn and each `@Tool` call run as
   separate checkpointed activities.
 - `@Tool` **beans** (not per-call `.defaultTools(...)`) are rediscovered on the restarted worker, so a
@@ -44,5 +48,18 @@ Each quickstart has its own README with the full run steps.
   chain. `DurableAdvisor` is terminal; an advisor's response phase (chat memory, logging, post-processing)
   runs synchronously *after a successful call* — so it is skipped on a crash/timeout. The
   **durable-memory** quickstart shows this and how re-attaching completes the chain.
+
+## Agent registration
+
+Durability and registration are separate packages. The starter makes an agent durable; a second
+dependency, `io.diagrid:diagrid-spring-ai-agent-registry`, is what records it as a Catalyst agent.
+
+The registry records one agent per `ChatClient` **bean**, named after the bean, filed under
+`diagrid.spring-ai.registry.app-id`. That app id must match the app's Dapr app id, or Catalyst drops
+the record with no error logged. A client built from the injected `ChatClient.Builder` is not a bean
+and so is never registered.
+
+**event-planner** wires this up; **crash-recovery** and **durable-memory** do not yet, so they run
+durably but register nothing.
 
 The library lives at [diagridio/java-ai](https://github.com/diagridio/java-ai).

--- a/agents/spring-ai/crash-recovery/src/main/java/io/diagrid/quickstart/springai/crashrecovery/CrashRecoveryAgentConfig.java
+++ b/agents/spring-ai/crash-recovery/src/main/java/io/diagrid/quickstart/springai/crashrecovery/CrashRecoveryAgentConfig.java
@@ -8,7 +8,8 @@ import org.springframework.context.annotation.Configuration;
  * Defines the booking agent as a <b>named {@link ChatClient} bean</b> so it runs under its own
  * per-agent workflow name ({@code spring-ai.crashRecoveryAgent.workflow}) instead of the generic
  * {@code spring-ai.workflow}. The name is assigned at wiring time from the bean name, and it shows up
- * in the Catalyst dashboard / {@code dapr workflow list}.
+ * in the Catalyst dashboard / {@code dapr workflow list}. The sibling {@code event-planner} quickstart
+ * does the same, for the same reason plus agent-registry registration.
  *
  * <p>It must be a {@code ChatClient} <em>bean</em> (not a {@code @Component} that holds a client): the
  * durability auto-config registers a per-agent workflow name on the in-process worker for every

--- a/agents/spring-ai/event-planner/README.md
+++ b/agents/spring-ai/event-planner/README.md
@@ -5,13 +5,14 @@ agent as a durable Dapr Workflow using the `io.diagrid:diagrid-spring-ai-starter
 acts as an **Event Planner** with three tools that it calls in sequence — tool 2 deliberately crashes
 the process to demonstrate automatic recovery.
 
-The app itself is **plain Spring AI** — a `ChatClient` + three `@Tool` beans + a REST endpoint. There
-is no durability code anywhere in it: adding the starter to the classpath is what turns every
-`ChatClient.call()` into a checkpointed Dapr Workflow.
+The app itself is **plain Spring AI** — a `ChatClient` bean + three `@Tool` beans + a REST endpoint.
+There is no durability code anywhere in it: adding the starter to the classpath is what turns every
+`ChatClient.call()` into a checkpointed Dapr Workflow. A second dependency,
+`diagrid-spring-ai-agent-registry`, records the `ChatClient` bean as a Catalyst agent.
 
 ## What This Quickstart Demonstrates
 
-- **Spring AI + Dapr Workflows**: run a Spring AI agent with durable execution — by adding one dependency, no code changes
+- **Spring AI + Dapr Workflows**: run a Spring AI agent with durable execution, added by dependency rather than by durability code
 - **OpenAI via Spring AI**: calls OpenAI directly through the `spring-ai-starter-model-openai` `ChatClient`
 - **Crash Recovery**: tool 2 crashes the process; on restart, Catalyst resumes the workflow automatically — completed steps are not re-run
 - **REST API**: trigger the agent via an HTTP endpoint
@@ -57,6 +58,11 @@ diagrid project create spring-ai-quickstart --enable-managed-workflow --wait --u
 diagrid agent create spring-ai-event-planner --wait
 diagrid dev run -f dev-spring-ai-event-planner.yaml --approve
 ```
+
+> `diagrid agent create` is **required**, not optional. It creates the App ID the agent registry files
+> this agent under, and the managed `agent-registry` connection is only scoped to App IDs backed by an
+> agent. `diagrid dev run` starts fine without it, but the agent registration then fails against a
+> connection it cannot load.
 
 ### 2. Trigger the Agent
 
@@ -122,13 +128,19 @@ and execution continues from `step_two_compare`:
 
 ## How It Works
 
-- `diagrid-spring-ai-starter` auto-configures a `DurableAdvisor` (attached to every `ChatClient` built
-  from the injected `ChatClient.Builder`) and an in-process Dapr Workflow worker.
+- `diagrid-spring-ai-starter` auto-configures a `DurableAdvisor` and an in-process Dapr Workflow
+  worker. Because the agent is a `ChatClient` **bean** (`EventPlannerAgentConfig`), the starter
+  attaches a *per-agent* advisor to that bean and names its workflow after it:
+  `spring-ai.spring-ai-event-planner.workflow`. A `ChatClient` built ad hoc from the injected
+  `ChatClient.Builder` instead gets the generic advisor and the shared `spring-ai.workflow` name.
 - Each `ChatClient.call()` runs as a Dapr Workflow; the model turn and each `@Tool` call run as
   separate **checkpointed activities**. A crash resumes from the last completed step — completed
   activities are replayed from history rather than re-executed.
 - The three tools are global `@Tool` beans, so they are rediscovered on the restarted worker and the
   resumed workflow can run the pending activity.
+- `diagrid-spring-ai-agent-registry` records the agent under the app id in `application.properties`,
+  named after the bean (`spring-ai-event-planner`). It derives the workflow name it records from that
+  same bean name, so the workflow on the agent record is the workflow that actually runs.
 
 > **A note on idempotency.** A durable activity is *at-least-once*: the tool that was in flight at
 > crash time re-runs on recovery. This quickstart's tools are side-effect-free, so re-running is

--- a/agents/spring-ai/event-planner/pom.xml
+++ b/agents/spring-ai/event-planner/pom.xml
@@ -66,12 +66,20 @@
       <artifactId>spring-ai-starter-model-openai</artifactId>
     </dependency>
 
-    <!-- THE ONLY THING THAT MAKES IT DURABLE: add the starter, change no application code.
+    <!-- WHAT MAKES IT DURABLE: add the starter, write no durability code.
          Every ChatClient.call() then runs as a Dapr Workflow whose model turns and tool calls are
-         checkpointed activities — so a crash resumes from the last completed step. -->
+         checkpointed activities, so a crash resumes from the last completed step. -->
     <dependency>
       <groupId>io.diagrid</groupId>
       <artifactId>diagrid-spring-ai-starter</artifactId>
+      <version>${diagrid-spring-ai.version}</version>
+    </dependency>
+
+    <!-- WHAT REGISTERS IT: records each ChatClient bean in the Catalyst agent registry, under the
+         app id, so the agent is discoverable as a Catalyst agent rather than just a running app. -->
+    <dependency>
+      <groupId>io.diagrid</groupId>
+      <artifactId>diagrid-spring-ai-agent-registry</artifactId>
       <version>${diagrid-spring-ai.version}</version>
     </dependency>
   </dependencies>

--- a/agents/spring-ai/event-planner/src/main/java/io/diagrid/quickstart/springai/eventplanner/EventPlannerAgentConfig.java
+++ b/agents/spring-ai/event-planner/src/main/java/io/diagrid/quickstart/springai/eventplanner/EventPlannerAgentConfig.java
@@ -1,0 +1,38 @@
+package io.diagrid.quickstart.springai.eventplanner;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Defines the event planner as a {@link ChatClient} bean. This is ordinary Spring AI: the client is
+ * still built from the injected {@link ChatClient.Builder}, so the durability layer attaches as it
+ * always has, and there is no diagrid API in application code.
+ *
+ * <p>Being a <em>bean</em> is what gets the agent registered. The agent registry discovers
+ * {@code ChatClient} beans and records one agent per bean, named after the bean, so this agent
+ * registers as {@code spring-ai-event-planner} under the Dapr app id set in
+ * {@code application.properties}.
+ *
+ * <p>That is why the {@code @Bean} annotation carries an explicit name: the registered agent name is
+ * the bean name verbatim. Both the durability layer and the registry derive the per-agent workflow
+ * name from that same bean name, so this agent runs as
+ * {@code spring-ai.spring-ai-event-planner.workflow} (visible in {@code dapr workflow list}) rather
+ * than the generic {@code spring-ai.workflow}, and the name recorded on the agent record is the
+ * workflow that actually runs.
+ */
+@Configuration
+public class EventPlannerAgentConfig {
+
+  private static final String SYSTEM = """
+      You are an event planner. Call all three tools in sequence:
+      1. First call step_one_search with the city name
+      2. Then call step_two_compare with the result from step 1
+      3. Finally call step_three_confirm with the result from step 2
+      Do NOT skip any steps.""";
+
+  @Bean("spring-ai-event-planner")
+  ChatClient eventPlanner(ChatClient.Builder builder) {
+    return builder.defaultSystem(SYSTEM).build();
+  }
+}

--- a/agents/spring-ai/event-planner/src/main/java/io/diagrid/quickstart/springai/eventplanner/EventPlannerController.java
+++ b/agents/spring-ai/event-planner/src/main/java/io/diagrid/quickstart/springai/eventplanner/EventPlannerController.java
@@ -6,28 +6,23 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * Ordinary Spring AI usage — no durability code. The {@link ChatClient} is built from the injected
- * {@link ChatClient.Builder}, which lets the diagrid-spring-ai {@code DurableAdvisor} attach automatically.
- * Every {@code chatClient...call()} then runs as a Dapr Workflow: the model turns and each tool call
- * are checkpointed activities, so a crash resumes from the last completed step.
+ * Ordinary Spring AI usage with no durability code. The {@link ChatClient} is the
+ * {@code spring-ai-event-planner} bean defined in {@link EventPlannerAgentConfig}, built there from
+ * the injected {@link ChatClient.Builder}, which lets the diagrid-spring-ai {@code DurableAdvisor}
+ * attach automatically. Every {@code chatClient...call()} then runs as a Dapr Workflow: the model
+ * turns and each tool call are checkpointed activities, so a crash resumes from the last completed
+ * step.
  *
  * <p>The three {@link EventPlannerTools} are global {@code @Tool} beans, so the durability layer offers
- * them to this agent automatically — no explicit {@code .defaultTools(...)} needed.
+ * them to this agent automatically, with no explicit {@code .defaultTools(...)} needed.
  */
 @RestController
 public class EventPlannerController {
 
-  private static final String SYSTEM = """
-      You are an event planner. Call all three tools in sequence:
-      1. First call step_one_search with the city name
-      2. Then call step_two_compare with the result from step 1
-      3. Finally call step_three_confirm with the result from step 2
-      Do NOT skip any steps.""";
-
   private final ChatClient chatClient;
 
-  public EventPlannerController(ChatClient.Builder builder) {
-    this.chatClient = builder.defaultSystem(SYSTEM).build();
+  public EventPlannerController(ChatClient chatClient) {
+    this.chatClient = chatClient;
   }
 
   @PostMapping("/run")

--- a/agents/spring-ai/event-planner/src/main/resources/application.properties
+++ b/agents/spring-ai/event-planner/src/main/resources/application.properties
@@ -15,6 +15,12 @@ spring.threads.virtual.enabled=true
 diagrid.spring-ai.enabled=true
 diagrid.spring-ai.completion-timeout=5m
 
+# ── Agent registry (diagrid-spring-ai-agent-registry) ────────────────────────
+# The app the registry files this agent under. It must equal spring.application.name above and the
+# appID in the dev-run file: Catalyst silently drops a record whose app id does not match the
+# sidecar's, with no error logged anywhere.
+diagrid.spring-ai.registry.app-id=spring-ai-event-planner
+
 # ── LLM: OpenAI via Spring AI ────────────────────────────────────────────────
 # Export OPENAI_API_KEY in the environment. Swap the model freely.
 spring.ai.openai.api-key=${OPENAI_API_KEY}


### PR DESCRIPTION
The event-planner quickstart runs durably, but the agent never showed up in Catalyst because it was never registered. This fixes that.

### Changes

- **Add the `diagrid-spring-ai-agent-registry` dependency.** Registration ships in a different package from the durability starter, and nothing was pulling it in.
- **Define the `ChatClient` as a named Spring bean** (`EventPlannerAgentConfig`). The registry only picks up `ChatClient` beans, and it uses the bean name as the agent name, so the bean is named `spring-ai-event-planner` to match the app.
- **Set `diagrid.spring-ai.registry.app-id` explicitly.** It resolves to the same value today, but it is worth pinning: if the app id ever stops matching the app, Catalyst discards the registration silently.
- **Update the docs these changes contradict**, including a line in crash-recovery that described event-planner's behaviour incorrectly.

### One behaviour change

Naming the bean also changes the workflow name, from the shared `spring-ai.workflow` to `spring-ai.spring-ai-event-planner.workflow`. This matches what the crash-recovery quickstart already does, and it keeps the workflow name stored on the agent pointing at the workflow that actually runs.

### Notes

- `diagrid agent create` is now required rather than conventional, and the README says so. The agent registry is only available to app IDs that have an agent, but `diagrid dev run` starts fine without one, so skipping it fails in a confusing way.
- The agent registers without a role or goal. The registry library cannot set those fields in 0.1.0, so they are blank where the Python quickstarts fill them in. Tracked in OSS-1749.
- crash-recovery and durable-memory have the same registration gap. Left for a separate change.

### Testing

All three Spring AI quickstarts build. Verified locally end to end: the agent registers and appears in the Catalyst UI.