### PR TITLE
chore: adopt diagrid-spring-ai 0.2.0 in the Spring AI quickstarts

### DIFF
--- a/agents/spring-ai/crash-recovery/README.md
+++ b/agents/spring-ai/crash-recovery/README.md
@@ -53,7 +53,7 @@ Log in, create the Catalyst project with managed workflow enabled (and set it as
 
 ```bash
 diagrid login
-diagrid project create spring-ai-crash-recovery --enable-managed-workflow --wait --use
+diagrid project create spring-ai-crash-recovery --enable-managed-workflow --deploy-managed-kv --wait --use
 diagrid agent create spring-ai-crash-recovery --wait
 diagrid dev run -f dev-spring-ai-crash-recovery.yaml --approve
 ```

--- a/agents/spring-ai/crash-recovery/pom.xml
+++ b/agents/spring-ai/crash-recovery/pom.xml
@@ -21,7 +21,7 @@
     <java.version>21</java.version>
     <spring-ai.version>2.0.0</spring-ai.version>
     <dapr.version>1.18.0</dapr.version>
-    <diagrid-spring-ai.version>0.1.0</diagrid-spring-ai.version>
+    <diagrid-spring-ai.version>0.2.0</diagrid-spring-ai.version>
   </properties>
 
   <dependencyManagement>

--- a/agents/spring-ai/crash-recovery/src/main/resources/application.properties
+++ b/agents/spring-ai/crash-recovery/src/main/resources/application.properties
@@ -16,6 +16,11 @@ spring.threads.virtual.enabled=true
 diagrid.spring-ai.enabled=true
 diagrid.spring-ai.completion-timeout=2m
 
+# ── Agent registry ───────────────────────────────────────────────────────────
+# On 0.2.0 the starter records this ChatClient bean (crashRecoveryAgent) as a Catalyst agent. Pin the
+# App ID (= spring.application.name above and the dev-run appID) so it is recorded under the right id.
+diagrid.spring-ai.registry.app-id=spring-ai-crash-recovery
+
 # How long commitReservation "commits" for — the window in which you kill the app.
 crash-recovery.delay-seconds=30
 

--- a/agents/spring-ai/durable-memory/pom.xml
+++ b/agents/spring-ai/durable-memory/pom.xml
@@ -21,7 +21,7 @@
     <java.version>21</java.version>
     <spring-ai.version>2.0.0</spring-ai.version>
     <dapr.version>1.18.0</dapr.version>
-    <diagrid-spring-ai.version>0.1.0</diagrid-spring-ai.version>
+    <diagrid-spring-ai.version>0.2.0</diagrid-spring-ai.version>
   </properties>
 
   <dependencyManagement>

--- a/agents/spring-ai/durable-memory/src/main/resources/application.properties
+++ b/agents/spring-ai/durable-memory/src/main/resources/application.properties
@@ -23,6 +23,12 @@ crash-recovery.delay-seconds=30
 diagrid.spring-ai.memory.enabled=true
 diagrid.spring-ai.memory.statestore=kvstore
 
+# ── Agent registry ───────────────────────────────────────────────────────────
+# This demo builds its ChatClient inline (not a bean), so there is nothing for the registry to record.
+# Turn it off to keep startup clean — otherwise 0.2.0's on-by-default registry logs an unset-app-id
+# warning even though no agent is registered.
+diagrid.spring-ai.registry.enabled=false
+
 # ── LLM: OpenAI via Spring AI ────────────────────────────────────────────────
 # Export OPENAI_API_KEY in the environment. Swap the model freely.
 spring.ai.openai.api-key=${OPENAI_API_KEY}

--- a/agents/spring-ai/event-planner/README.md
+++ b/agents/spring-ai/event-planner/README.md
@@ -7,8 +7,8 @@ the process to demonstrate automatic recovery.
 
 The app itself is **plain Spring AI** — a `ChatClient` bean + three `@Tool` beans + a REST endpoint.
 There is no durability code anywhere in it: adding the starter to the classpath is what turns every
-`ChatClient.call()` into a checkpointed Dapr Workflow. A second dependency,
-`diagrid-spring-ai-agent-registry`, records the `ChatClient` bean as a Catalyst agent.
+`ChatClient.call()` into a checkpointed Dapr Workflow — and, as of 0.2.0, the starter also records the
+`ChatClient` bean as a Catalyst agent (registration ships in the starter, no separate dependency).
 
 ## What This Quickstart Demonstrates
 
@@ -54,7 +54,7 @@ Log in, create the Catalyst project with managed workflow enabled (and set it as
 
 ```bash
 diagrid login
-diagrid project create spring-ai-quickstart --enable-managed-workflow --wait --use
+diagrid project create spring-ai-quickstart --enable-managed-workflow --deploy-managed-kv --wait --use
 diagrid agent create spring-ai-event-planner --wait
 diagrid dev run -f dev-spring-ai-event-planner.yaml --approve
 ```
@@ -138,9 +138,9 @@ and execution continues from `step_two_compare`:
   activities are replayed from history rather than re-executed.
 - The three tools are global `@Tool` beans, so they are rediscovered on the restarted worker and the
   resumed workflow can run the pending activity.
-- `diagrid-spring-ai-agent-registry` records the agent under the app id in `application.properties`,
-  named after the bean (`spring-ai-event-planner`). It derives the workflow name it records from that
-  same bean name, so the workflow on the agent record is the workflow that actually runs.
+- The **starter** records the agent under the app id in `application.properties`, named after the
+  bean (`spring-ai-event-planner`). It derives the workflow name it records from that same bean name,
+  so the workflow on the agent record is the workflow that actually runs.
 
 > **A note on idempotency.** A durable activity is *at-least-once*: the tool that was in flight at
 > crash time re-runs on recovery. This quickstart's tools are side-effect-free, so re-running is

--- a/agents/spring-ai/event-planner/pom.xml
+++ b/agents/spring-ai/event-planner/pom.xml
@@ -21,7 +21,7 @@
     <java.version>21</java.version>
     <spring-ai.version>2.0.0</spring-ai.version>
     <dapr.version>1.18.0</dapr.version>
-    <diagrid-spring-ai.version>0.1.0</diagrid-spring-ai.version>
+    <diagrid-spring-ai.version>0.2.0</diagrid-spring-ai.version>
   </properties>
 
   <dependencyManagement>
@@ -66,20 +66,14 @@
       <artifactId>spring-ai-starter-model-openai</artifactId>
     </dependency>
 
-    <!-- WHAT MAKES IT DURABLE: add the starter, write no durability code.
-         Every ChatClient.call() then runs as a Dapr Workflow whose model turns and tool calls are
-         checkpointed activities, so a crash resumes from the last completed step. -->
+    <!-- WHAT MAKES IT DURABLE (and registers it): add the starter, write no durability code. Every
+         ChatClient.call() then runs as a Dapr Workflow whose model turns and tool calls are
+         checkpointed activities (so a crash resumes from the last completed step), and each
+         ChatClient bean is recorded in the Catalyst agent registry. As of 0.2.0 the registry ships
+         in the starter — no separate diagrid-spring-ai-agent-registry dependency. -->
     <dependency>
       <groupId>io.diagrid</groupId>
       <artifactId>diagrid-spring-ai-starter</artifactId>
-      <version>${diagrid-spring-ai.version}</version>
-    </dependency>
-
-    <!-- WHAT REGISTERS IT: records each ChatClient bean in the Catalyst agent registry, under the
-         app id, so the agent is discoverable as a Catalyst agent rather than just a running app. -->
-    <dependency>
-      <groupId>io.diagrid</groupId>
-      <artifactId>diagrid-spring-ai-agent-registry</artifactId>
       <version>${diagrid-spring-ai.version}</version>
     </dependency>
   </dependencies>

--- a/agents/spring-ai/event-planner/src/main/resources/application.properties
+++ b/agents/spring-ai/event-planner/src/main/resources/application.properties
@@ -15,10 +15,10 @@ spring.threads.virtual.enabled=true
 diagrid.spring-ai.enabled=true
 diagrid.spring-ai.completion-timeout=5m
 
-# ── Agent registry (diagrid-spring-ai-agent-registry) ────────────────────────
-# The app the registry files this agent under. It must equal spring.application.name above and the
-# appID in the dev-run file: Catalyst silently drops a record whose app id does not match the
-# sidecar's, with no error logged anywhere.
+# ── Agent registry ───────────────────────────────────────────────────────────
+# The App ID this agent is recorded under (registration ships in the starter). It must equal
+# spring.application.name above and the appID in the dev-run file, or Catalyst drops the record with
+# no error logged anywhere.
 diagrid.spring-ai.registry.app-id=spring-ai-event-planner
 
 # ── LLM: OpenAI via Spring AI ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adopt **`diagrid-spring-ai` 0.2.0** across the three Spring AI quickstarts. 0.2.0 folds the agent registry into `diagrid-spring-ai-starter` (diagridio/java-ai#43), so the separate `diagrid-spring-ai-agent-registry` dependency no longer exists — registration ships in the starter, on by default.

## event-planner
- pom: `0.1.0` → `0.2.0`; **drop** the `diagrid-spring-ai-agent-registry` dependency.
- README: "second dependency" → "ships in the starter"; **added `--deploy-managed-kv`** to `diagrid project create` — the agent registry needs the managed KV store and the command was missing it (independent bug from #285).
- properties: `registry.app-id` comment de-Dapr'd, removed-module name dropped.

## crash-recovery
- pom: `0.1.0` → `0.2.0`. It has a `ChatClient` bean, so on 0.2.0 the starter **auto-registers** it.
- **added `--deploy-managed-kv`** to the create command + pinned `registry.app-id=spring-ai-crash-recovery` so registration lands cleanly (it already runs `diagrid agent create`).

## durable-memory
- pom: `0.1.0` → `0.2.0`. Its `ChatClient` is built inline (nothing to register), so set **`registry.enabled=false`** — avoids 0.2.0's on-by-default registry logging a spurious unset-app-id warning at startup. Already has `--deploy-managed-kv` for chat memory.

No application code changed — each module's beans, tools, and dev-run files are untouched (event-planner's crash `halt(1)` line stays active).

## Verification
`io.diagrid:diagrid-spring-ai-*:0.2.0` is **live on Maven Central**. All three modules `mvn clean test-compile` against `0.2.0` — **BUILD SUCCESS**. event-planner sanity-run on Catalyst confirmed the agent registers with the starter alone.

Pairs with the library merge diagridio/java-ai#43.
