### PR TITLE
fix: use agent-registry store for AgentRegistryConfig

### DIFF
--- a/agents/dapr-agents/durable-agent/main.py
+++ b/agents/dapr-agents/durable-agent/main.py
@@ -60,7 +60,7 @@ def main() -> None:
             ),
         ),
         registry=AgentRegistryConfig(
-            store=StateStoreService(store_name="kvstore"),
+            store=StateStoreService(store_name="agent-registry"),
         ),
         pubsub=AgentPubSubConfig(
             pubsub_name="pubsub",

--- a/agents/dapr-agents/orchestrator/main.py
+++ b/agents/dapr-agents/orchestrator/main.py
@@ -36,7 +36,7 @@ def main() -> None:
             store=StateStoreService(store_name="kvstore", key_prefix="event-coordinator:"),
         ),
         registry=AgentRegistryConfig(
-            store=StateStoreService(store_name="kvstore"),
+            store=StateStoreService(store_name="agent-registry"),
         ),
         execution=AgentExecutionConfig(
             max_iterations=25,


### PR DESCRIPTION
https://github.com/diagridio/catalyst-quickstarts/pull/283 changed the registry store name from `agent-registry` to `kvstore`. The Catalyst sidecar's AgentsRegistryInterceptor is a targeted interceptor that only intercepts writes to the agent-registry component. Writes to kvstore bypass the interceptor entirely, so agent metadata never reaches the Postgres agents table, which cause `dg agent registry` list returns empty.